### PR TITLE
Updates to OS notebook

### DIFF
--- a/notebooks/frequentist_optimalstatistic_analysis.ipynb
+++ b/notebooks/frequentist_optimalstatistic_analysis.ipynb
@@ -8,16 +8,31 @@
     "\n",
     "In this notebook you will learn how to compute the optimal statistic. The optimal statistic is a frequentist detection statistic for the stochastic background. It assesses the significance of the cross-correlations, and compares them to the Hellings-Downs curve.\n",
     "\n",
-    "For more information, see Anholm et al. 2009, Demorest et al. 2013, Chamberlin et al. 2015, Vigeland et al. 2018.\n",
+    "For more information, see [Anholm et al. 2009](https://arxiv.org/abs/0809.0701), [Demorest et al. 2013](https://arxiv.org/abs/1201.6641), [Chamberlin et al. 2015](https://arxiv.org/abs/1410.8256), [Vigeland et al. 2018](https://arxiv.org/abs/1805.12188).\n",
     "\n",
     "This notebook shows you how to compute the optimal statistic for the 12.5yr data set. You can download a pickle of the pulsars and the noisefiles here: https://paper.dropbox.com/doc/NG-12.5yr_v3-GWB-Analysis--A2vs2wHh5gR4VTgm2DeODR2zAg-DICJei6NxsPjxnO90mGMo"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
+   "source": [
+    "## Imports, data loading, and setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cannot import PINT? Meh...\n"
+     ]
+    }
+   ],
    "source": [
     "from __future__ import (absolute_import, division,\n",
     "                        print_function, unicode_literals)\n",
@@ -32,18 +47,32 @@
     "from enterprise.signals import gp_signals\n",
     "\n",
     "from enterprise_extensions import model_utils, blocks\n",
-    "from enterprise_extensions.frequentist import optimal_statistic as opt_stat"
+    "from enterprise_extensions.frequentist import optimal_statistic as opt_stat\n",
+    "\n",
+    "import h5py"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "45"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Load up the pulsars from the pickle file\n",
     "# Change the picklefile to point to where you have saved the pickle of the pulsars that you downloaded\n",
-    "picklefile = '/Users/vigeland/Documents/Research/NANOGrav/nanograv_data/12p5yr/channelized_v3_DE438_45psrs.pkl'\n",
+    "#picklefile = '/Users/vigeland/Documents/Research/NANOGrav/nanograv_data/12p5yr/channelized_v3_DE438_45psrs.pkl'\n",
+    "picklefile = '/home/beno/Dropbox/Szakma/Research/BayesHopperRealData/12_5yr/channelized_12yr_v3_partim_DE438.pkl'\n",
     "\n",
     "with open(picklefile, 'rb') as f:\n",
     "    psrs = pickle.load(f)\n",
@@ -52,13 +81,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Load up the noise dictionary to get values for the white noise parameters\n",
     "# Change the noisefile to point to where you have saved the noisefile\n",
-    "noisefile = '/Users/vigeland/Documents/Research/NANOGrav/nanograv_data/12p5yr/channelized_12p5yr_v3_full_noisedict.json'\n",
+    "noisefile = '../data/channelized_12p5yr_v3_full_noisedict.json'\n",
     "\n",
     "with open(noisefile, 'r') as f:\n",
     "    noisedict = json.load(f)"
@@ -66,10 +95,540 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: enterprise.signals.signal_base: Setting B1855+09_430_ASP_efac to 1.149036589204419\n",
+      "INFO: enterprise.signals.signal_base: Setting B1855+09_430_PUPPI_efac to 1.0543836580555548\n",
+      "INFO: enterprise.signals.signal_base: Setting B1855+09_L-wide_ASP_efac to 1.080749375878354\n",
+      "INFO: enterprise.signals.signal_base: Setting B1855+09_L-wide_PUPPI_efac to 1.2429537099744354\n",
+      "INFO: enterprise.signals.signal_base: Setting B1855+09_430_ASP_log10_equad to -7.379759355541006\n",
+      "INFO: enterprise.signals.signal_base: Setting B1855+09_430_PUPPI_log10_equad to -6.348065001180634\n",
+      "INFO: enterprise.signals.signal_base: Setting B1855+09_L-wide_ASP_log10_equad to -6.51289896375955\n",
+      "INFO: enterprise.signals.signal_base: Setting B1855+09_L-wide_PUPPI_log10_equad to -7.821737281350602\n",
+      "INFO: enterprise.signals.signal_base: Setting B1855+09_430_ASP_log10_ecorr to -7.415374510054153\n",
+      "INFO: enterprise.signals.signal_base: Setting B1855+09_430_PUPPI_log10_ecorr to -5.671108063699219\n",
+      "INFO: enterprise.signals.signal_base: Setting B1855+09_L-wide_ASP_log10_ecorr to -6.092899143243734\n",
+      "INFO: enterprise.signals.signal_base: Setting B1855+09_L-wide_PUPPI_log10_ecorr to -6.641281263572077\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_L-wide_ASP_efac to 2.048754020884262\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_L-wide_PUPPI_efac to 2.12041666470792\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_Rcvr1_2_GASP_efac to 1.1708200812403644\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_Rcvr1_2_GUPPI_efac to 1.4415081390299156\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_Rcvr_800_GASP_efac to 2.1333453783210095\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_Rcvr_800_GUPPI_efac to 4.219838621260683\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_S-wide_ASP_efac to 1.5159731379775645\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_S-wide_PUPPI_efac to 1.2470571693911434\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_L-wide_ASP_log10_equad to -6.785369742733748\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_L-wide_PUPPI_log10_equad to -7.147037241326325\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_Rcvr1_2_GASP_log10_equad to -7.028404298685201\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_Rcvr1_2_GUPPI_log10_equad to -7.139419197676975\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_Rcvr_800_GASP_log10_equad to -6.669528646515994\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_Rcvr_800_GUPPI_log10_equad to -6.603208890098822\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_S-wide_ASP_log10_equad to -6.781862531120971\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_S-wide_PUPPI_log10_equad to -7.011196636087005\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_L-wide_ASP_log10_ecorr to -6.940958996081342\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_L-wide_PUPPI_log10_ecorr to -7.037572450266321\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_Rcvr1_2_GASP_log10_ecorr to -6.9573181220861695\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_Rcvr1_2_GUPPI_log10_ecorr to -6.873056983920257\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_Rcvr_800_GASP_log10_ecorr to -8.024096164984243\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_Rcvr_800_GUPPI_log10_ecorr to -6.441588828662218\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_S-wide_ASP_log10_ecorr to -6.55920330997421\n",
+      "INFO: enterprise.signals.signal_base: Setting B1937+21_S-wide_PUPPI_log10_ecorr to -6.867655505641185\n",
+      "INFO: enterprise.signals.signal_base: Setting B1953+29_430_ASP_efac to 1.0959834459004414\n",
+      "INFO: enterprise.signals.signal_base: Setting B1953+29_430_PUPPI_efac to 1.2278825282026293\n",
+      "INFO: enterprise.signals.signal_base: Setting B1953+29_L-wide_ASP_efac to 1.3518344895001828\n",
+      "INFO: enterprise.signals.signal_base: Setting B1953+29_L-wide_PUPPI_efac to 1.0614508352845797\n",
+      "INFO: enterprise.signals.signal_base: Setting B1953+29_430_ASP_log10_equad to -6.968461432753658\n",
+      "INFO: enterprise.signals.signal_base: Setting B1953+29_430_PUPPI_log10_equad to -7.04610187176654\n",
+      "INFO: enterprise.signals.signal_base: Setting B1953+29_L-wide_ASP_log10_equad to -6.883663754457833\n",
+      "INFO: enterprise.signals.signal_base: Setting B1953+29_L-wide_PUPPI_log10_equad to -7.463758861348976\n",
+      "INFO: enterprise.signals.signal_base: Setting B1953+29_430_ASP_log10_ecorr to -6.708721056458093\n",
+      "INFO: enterprise.signals.signal_base: Setting B1953+29_430_PUPPI_log10_ecorr to -5.228786570159053\n",
+      "INFO: enterprise.signals.signal_base: Setting B1953+29_L-wide_ASP_log10_ecorr to -7.041138848116017\n",
+      "INFO: enterprise.signals.signal_base: Setting B1953+29_L-wide_PUPPI_log10_ecorr to -7.385606441924905\n",
+      "INFO: enterprise.signals.signal_base: Setting J0023+0923_430_ASP_efac to 1.0406298798508282\n",
+      "INFO: enterprise.signals.signal_base: Setting J0023+0923_430_PUPPI_efac to 1.0303417825587\n",
+      "INFO: enterprise.signals.signal_base: Setting J0023+0923_L-wide_ASP_efac to 1.1650439914860966\n",
+      "INFO: enterprise.signals.signal_base: Setting J0023+0923_L-wide_PUPPI_efac to 1.1184544897926894\n",
+      "INFO: enterprise.signals.signal_base: Setting J0023+0923_430_ASP_log10_equad to -7.515587544312441\n",
+      "INFO: enterprise.signals.signal_base: Setting J0023+0923_430_PUPPI_log10_equad to -6.854981065840284\n",
+      "INFO: enterprise.signals.signal_base: Setting J0023+0923_L-wide_ASP_log10_equad to -6.969754197772692\n",
+      "INFO: enterprise.signals.signal_base: Setting J0023+0923_L-wide_PUPPI_log10_equad to -7.039565135200931\n",
+      "INFO: enterprise.signals.signal_base: Setting J0023+0923_430_ASP_log10_ecorr to -7.247114834645301\n",
+      "INFO: enterprise.signals.signal_base: Setting J0023+0923_430_PUPPI_log10_ecorr to -7.204956301397655\n",
+      "INFO: enterprise.signals.signal_base: Setting J0023+0923_L-wide_ASP_log10_ecorr to -7.090334519441014\n",
+      "INFO: enterprise.signals.signal_base: Setting J0023+0923_L-wide_PUPPI_log10_ecorr to -7.815809476021381\n",
+      "INFO: enterprise.signals.signal_base: Setting J0030+0451_430_ASP_efac to 1.178988376393598\n",
+      "INFO: enterprise.signals.signal_base: Setting J0030+0451_430_PUPPI_efac to 1.0168220759726072\n",
+      "INFO: enterprise.signals.signal_base: Setting J0030+0451_L-wide_ASP_efac to 1.1594082526710712\n",
+      "INFO: enterprise.signals.signal_base: Setting J0030+0451_L-wide_PUPPI_efac to 1.1157243178133207\n",
+      "INFO: enterprise.signals.signal_base: Setting J0030+0451_S-wide_PUPPI_efac to 0.991497940413971\n",
+      "INFO: enterprise.signals.signal_base: Setting J0030+0451_430_ASP_log10_equad to -7.60151264056324\n",
+      "INFO: enterprise.signals.signal_base: Setting J0030+0451_430_PUPPI_log10_equad to -7.8144222164663235\n",
+      "INFO: enterprise.signals.signal_base: Setting J0030+0451_L-wide_ASP_log10_equad to -7.526120409087749\n",
+      "INFO: enterprise.signals.signal_base: Setting J0030+0451_L-wide_PUPPI_log10_equad to -7.687444375922908\n",
+      "INFO: enterprise.signals.signal_base: Setting J0030+0451_S-wide_PUPPI_log10_equad to -7.396119136419303\n",
+      "INFO: enterprise.signals.signal_base: Setting J0030+0451_430_ASP_log10_ecorr to -7.637597883725108\n",
+      "INFO: enterprise.signals.signal_base: Setting J0030+0451_430_PUPPI_log10_ecorr to -7.458377805782614\n",
+      "INFO: enterprise.signals.signal_base: Setting J0030+0451_L-wide_ASP_log10_ecorr to -7.652790501212441\n",
+      "INFO: enterprise.signals.signal_base: Setting J0030+0451_L-wide_PUPPI_log10_ecorr to -7.712152616003756\n",
+      "INFO: enterprise.signals.signal_base: Setting J0030+0451_S-wide_PUPPI_log10_ecorr to -7.4855687647637446\n",
+      "INFO: enterprise.signals.signal_base: Setting J0340+4130_Rcvr1_2_GUPPI_efac to 1.0259642829541946\n",
+      "INFO: enterprise.signals.signal_base: Setting J0340+4130_Rcvr_800_GUPPI_efac to 1.0538137141624955\n",
+      "INFO: enterprise.signals.signal_base: Setting J0340+4130_Rcvr1_2_GUPPI_log10_equad to -7.386039778629237\n",
+      "INFO: enterprise.signals.signal_base: Setting J0340+4130_Rcvr_800_GUPPI_log10_equad to -7.3382576654191105\n",
+      "INFO: enterprise.signals.signal_base: Setting J0340+4130_Rcvr1_2_GUPPI_log10_ecorr to -7.622018530342815\n",
+      "INFO: enterprise.signals.signal_base: Setting J0340+4130_Rcvr_800_GUPPI_log10_ecorr to -7.393209598102237\n",
+      "INFO: enterprise.signals.signal_base: Setting J0613-0200_Rcvr1_2_GASP_efac to 1.0670783724500694\n",
+      "INFO: enterprise.signals.signal_base: Setting J0613-0200_Rcvr1_2_GUPPI_efac to 1.0430747567523209\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: enterprise.signals.signal_base: Setting J0613-0200_Rcvr_800_GASP_efac to 1.0914149510171187\n",
+      "INFO: enterprise.signals.signal_base: Setting J0613-0200_Rcvr_800_GUPPI_efac to 1.1066698572535434\n",
+      "INFO: enterprise.signals.signal_base: Setting J0613-0200_Rcvr1_2_GASP_log10_equad to -7.5596546617250215\n",
+      "INFO: enterprise.signals.signal_base: Setting J0613-0200_Rcvr1_2_GUPPI_log10_equad to -7.616764039524012\n",
+      "INFO: enterprise.signals.signal_base: Setting J0613-0200_Rcvr_800_GASP_log10_equad to -7.6069868785882795\n",
+      "INFO: enterprise.signals.signal_base: Setting J0613-0200_Rcvr_800_GUPPI_log10_equad to -6.650927606600988\n",
+      "INFO: enterprise.signals.signal_base: Setting J0613-0200_Rcvr1_2_GASP_log10_ecorr to -7.518791621441214\n",
+      "INFO: enterprise.signals.signal_base: Setting J0613-0200_Rcvr1_2_GUPPI_log10_ecorr to -6.783106192555926\n",
+      "INFO: enterprise.signals.signal_base: Setting J0613-0200_Rcvr_800_GASP_log10_ecorr to -7.737621417529334\n",
+      "INFO: enterprise.signals.signal_base: Setting J0613-0200_Rcvr_800_GUPPI_log10_ecorr to -6.785665911883737\n",
+      "INFO: enterprise.signals.signal_base: Setting J0636+5128_Rcvr1_2_GUPPI_efac to 1.0545966243498794\n",
+      "INFO: enterprise.signals.signal_base: Setting J0636+5128_Rcvr_800_GUPPI_efac to 1.0078085497374172\n",
+      "INFO: enterprise.signals.signal_base: Setting J0636+5128_Rcvr1_2_GUPPI_log10_equad to -7.529112931457501\n",
+      "INFO: enterprise.signals.signal_base: Setting J0636+5128_Rcvr_800_GUPPI_log10_equad to -6.971968785693322\n",
+      "INFO: enterprise.signals.signal_base: Setting J0636+5128_Rcvr1_2_GUPPI_log10_ecorr to -7.48542286828852\n",
+      "INFO: enterprise.signals.signal_base: Setting J0636+5128_Rcvr_800_GUPPI_log10_ecorr to -7.447351667842772\n",
+      "INFO: enterprise.signals.signal_base: Setting J0645+5158_Rcvr1_2_GUPPI_efac to 1.0435585167422876\n",
+      "INFO: enterprise.signals.signal_base: Setting J0645+5158_Rcvr_800_GUPPI_efac to 0.978554109695437\n",
+      "INFO: enterprise.signals.signal_base: Setting J0645+5158_Rcvr1_2_GUPPI_log10_equad to -7.513289178616864\n",
+      "INFO: enterprise.signals.signal_base: Setting J0645+5158_Rcvr_800_GUPPI_log10_equad to -7.062675708760795\n",
+      "INFO: enterprise.signals.signal_base: Setting J0645+5158_Rcvr1_2_GUPPI_log10_ecorr to -7.469787739972568\n",
+      "INFO: enterprise.signals.signal_base: Setting J0645+5158_Rcvr_800_GUPPI_log10_ecorr to -7.21903125633763\n",
+      "INFO: enterprise.signals.signal_base: Setting J0740+6620_Rcvr1_2_GUPPI_efac to 1.0343089991269732\n",
+      "INFO: enterprise.signals.signal_base: Setting J0740+6620_Rcvr_800_GUPPI_efac to 1.004701602096265\n",
+      "INFO: enterprise.signals.signal_base: Setting J0740+6620_Rcvr1_2_GUPPI_log10_equad to -7.761528816628728\n",
+      "INFO: enterprise.signals.signal_base: Setting J0740+6620_Rcvr_800_GUPPI_log10_equad to -7.164147505224222\n",
+      "INFO: enterprise.signals.signal_base: Setting J0740+6620_Rcvr1_2_GUPPI_log10_ecorr to -7.70608072561388\n",
+      "INFO: enterprise.signals.signal_base: Setting J0740+6620_Rcvr_800_GUPPI_log10_ecorr to -7.332857509784389\n",
+      "INFO: enterprise.signals.signal_base: Setting J0931-1902_Rcvr1_2_GUPPI_efac to 0.9978266264621855\n",
+      "INFO: enterprise.signals.signal_base: Setting J0931-1902_Rcvr_800_GUPPI_efac to 1.0273179327732913\n",
+      "INFO: enterprise.signals.signal_base: Setting J0931-1902_Rcvr1_2_GUPPI_log10_equad to -6.368762394081646\n",
+      "INFO: enterprise.signals.signal_base: Setting J0931-1902_Rcvr_800_GUPPI_log10_equad to -7.395637610513801\n",
+      "INFO: enterprise.signals.signal_base: Setting J0931-1902_Rcvr1_2_GUPPI_log10_ecorr to -7.513888675725786\n",
+      "INFO: enterprise.signals.signal_base: Setting J0931-1902_Rcvr_800_GUPPI_log10_ecorr to -7.493009784535781\n",
+      "INFO: enterprise.signals.signal_base: Setting J1012+5307_Rcvr1_2_GASP_efac to 1.0591690736069472\n",
+      "INFO: enterprise.signals.signal_base: Setting J1012+5307_Rcvr1_2_GUPPI_efac to 1.0062638587421908\n",
+      "INFO: enterprise.signals.signal_base: Setting J1012+5307_Rcvr_800_GASP_efac to 1.134064401904284\n",
+      "INFO: enterprise.signals.signal_base: Setting J1012+5307_Rcvr_800_GUPPI_efac to 1.062753909375921\n",
+      "INFO: enterprise.signals.signal_base: Setting J1012+5307_Rcvr1_2_GASP_log10_equad to -7.337569048606985\n",
+      "INFO: enterprise.signals.signal_base: Setting J1012+5307_Rcvr1_2_GUPPI_log10_equad to -7.777675843382624\n",
+      "INFO: enterprise.signals.signal_base: Setting J1012+5307_Rcvr_800_GASP_log10_equad to -7.335838608622016\n",
+      "INFO: enterprise.signals.signal_base: Setting J1012+5307_Rcvr_800_GUPPI_log10_equad to -6.506908723632507\n",
+      "INFO: enterprise.signals.signal_base: Setting J1012+5307_Rcvr1_2_GASP_log10_ecorr to -6.520878820970742\n",
+      "INFO: enterprise.signals.signal_base: Setting J1012+5307_Rcvr1_2_GUPPI_log10_ecorr to -6.39401084619692\n",
+      "INFO: enterprise.signals.signal_base: Setting J1012+5307_Rcvr_800_GASP_log10_ecorr to -7.672411945457032\n",
+      "INFO: enterprise.signals.signal_base: Setting J1012+5307_Rcvr_800_GUPPI_log10_ecorr to -7.741968522547623\n",
+      "INFO: enterprise.signals.signal_base: Setting J1024-0719_Rcvr1_2_GASP_efac to 0.910756763515209\n",
+      "INFO: enterprise.signals.signal_base: Setting J1024-0719_Rcvr1_2_GUPPI_efac to 1.0291119595206812\n",
+      "INFO: enterprise.signals.signal_base: Setting J1024-0719_Rcvr_800_GASP_efac to 0.9894501502567977\n",
+      "INFO: enterprise.signals.signal_base: Setting J1024-0719_Rcvr_800_GUPPI_efac to 1.0271589257321567\n",
+      "INFO: enterprise.signals.signal_base: Setting J1024-0719_Rcvr1_2_GASP_log10_equad to -6.739263270711485\n",
+      "INFO: enterprise.signals.signal_base: Setting J1024-0719_Rcvr1_2_GUPPI_log10_equad to -7.7609576526780275\n",
+      "INFO: enterprise.signals.signal_base: Setting J1024-0719_Rcvr_800_GASP_log10_equad to -7.194552724916308\n",
+      "INFO: enterprise.signals.signal_base: Setting J1024-0719_Rcvr_800_GUPPI_log10_equad to -7.836287384896643\n",
+      "INFO: enterprise.signals.signal_base: Setting J1024-0719_Rcvr1_2_GASP_log10_ecorr to -7.131954410884169\n",
+      "INFO: enterprise.signals.signal_base: Setting J1024-0719_Rcvr1_2_GUPPI_log10_ecorr to -6.700450821263385\n",
+      "INFO: enterprise.signals.signal_base: Setting J1024-0719_Rcvr_800_GASP_log10_ecorr to -7.066941892042146\n",
+      "INFO: enterprise.signals.signal_base: Setting J1024-0719_Rcvr_800_GUPPI_log10_ecorr to -7.348793203212565\n",
+      "INFO: enterprise.signals.signal_base: Setting J1125+7819_Rcvr1_2_GUPPI_efac to 1.0722721363434835\n",
+      "INFO: enterprise.signals.signal_base: Setting J1125+7819_Rcvr_800_GUPPI_efac to 1.0493747978072194\n",
+      "INFO: enterprise.signals.signal_base: Setting J1125+7819_Rcvr1_2_GUPPI_log10_equad to -6.551388027613723\n",
+      "INFO: enterprise.signals.signal_base: Setting J1125+7819_Rcvr_800_GUPPI_log10_equad to -5.746485292586326\n",
+      "INFO: enterprise.signals.signal_base: Setting J1125+7819_Rcvr1_2_GUPPI_log10_ecorr to -7.396928155031416\n",
+      "INFO: enterprise.signals.signal_base: Setting J1125+7819_Rcvr_800_GUPPI_log10_ecorr to -5.303607335077735\n",
+      "INFO: enterprise.signals.signal_base: Setting J1453+1902_430_PUPPI_efac to 0.9986419831773875\n",
+      "INFO: enterprise.signals.signal_base: Setting J1453+1902_L-wide_PUPPI_efac to 1.250519936636853\n",
+      "INFO: enterprise.signals.signal_base: Setting J1453+1902_430_PUPPI_log10_equad to -7.086976292634596\n",
+      "INFO: enterprise.signals.signal_base: Setting J1453+1902_L-wide_PUPPI_log10_equad to -7.409174757107404\n",
+      "INFO: enterprise.signals.signal_base: Setting J1453+1902_430_PUPPI_log10_ecorr to -6.893606742780536\n",
+      "INFO: enterprise.signals.signal_base: Setting J1453+1902_L-wide_PUPPI_log10_ecorr to -7.349945132590309\n",
+      "INFO: enterprise.signals.signal_base: Setting J1455-3330_Rcvr1_2_GASP_efac to 1.1400870761562596\n",
+      "INFO: enterprise.signals.signal_base: Setting J1455-3330_Rcvr1_2_GUPPI_efac to 1.082303099576083\n",
+      "INFO: enterprise.signals.signal_base: Setting J1455-3330_Rcvr_800_GASP_efac to 1.2328191470185799\n",
+      "INFO: enterprise.signals.signal_base: Setting J1455-3330_Rcvr_800_GUPPI_efac to 1.0054353177825495\n",
+      "INFO: enterprise.signals.signal_base: Setting J1455-3330_Rcvr1_2_GASP_log10_equad to -7.192520761470676\n",
+      "INFO: enterprise.signals.signal_base: Setting J1455-3330_Rcvr1_2_GUPPI_log10_equad to -7.524353545826194\n",
+      "INFO: enterprise.signals.signal_base: Setting J1455-3330_Rcvr_800_GASP_log10_equad to -7.050869987259775\n",
+      "INFO: enterprise.signals.signal_base: Setting J1455-3330_Rcvr_800_GUPPI_log10_equad to -7.558835853872056\n",
+      "INFO: enterprise.signals.signal_base: Setting J1455-3330_Rcvr1_2_GASP_log10_ecorr to -5.860332688998369\n",
+      "INFO: enterprise.signals.signal_base: Setting J1455-3330_Rcvr1_2_GUPPI_log10_ecorr to -7.629255580321534\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: enterprise.signals.signal_base: Setting J1455-3330_Rcvr_800_GASP_log10_ecorr to -7.085458304995403\n",
+      "INFO: enterprise.signals.signal_base: Setting J1455-3330_Rcvr_800_GUPPI_log10_ecorr to -6.526567653068877\n",
+      "INFO: enterprise.signals.signal_base: Setting J1600-3053_Rcvr1_2_GASP_efac to 1.134993789980654\n",
+      "INFO: enterprise.signals.signal_base: Setting J1600-3053_Rcvr1_2_GUPPI_efac to 1.0521556985294778\n",
+      "INFO: enterprise.signals.signal_base: Setting J1600-3053_Rcvr_800_GASP_efac to 1.1935927243559799\n",
+      "INFO: enterprise.signals.signal_base: Setting J1600-3053_Rcvr_800_GUPPI_efac to 1.120996265055496\n",
+      "INFO: enterprise.signals.signal_base: Setting J1600-3053_Rcvr1_2_GASP_log10_equad to -6.960586084616913\n",
+      "INFO: enterprise.signals.signal_base: Setting J1600-3053_Rcvr1_2_GUPPI_log10_equad to -7.761043891506745\n",
+      "INFO: enterprise.signals.signal_base: Setting J1600-3053_Rcvr_800_GASP_log10_equad to -7.311693997685966\n",
+      "INFO: enterprise.signals.signal_base: Setting J1600-3053_Rcvr_800_GUPPI_log10_equad to -7.374528725467375\n",
+      "INFO: enterprise.signals.signal_base: Setting J1600-3053_Rcvr1_2_GASP_log10_ecorr to -7.134558712552095\n",
+      "INFO: enterprise.signals.signal_base: Setting J1600-3053_Rcvr1_2_GUPPI_log10_ecorr to -6.899208552923536\n",
+      "INFO: enterprise.signals.signal_base: Setting J1600-3053_Rcvr_800_GASP_log10_ecorr to -7.407293847566683\n",
+      "INFO: enterprise.signals.signal_base: Setting J1600-3053_Rcvr_800_GUPPI_log10_ecorr to -6.288542964735563\n",
+      "INFO: enterprise.signals.signal_base: Setting J1614-2230_Rcvr1_2_GASP_efac to 1.1369056644435913\n",
+      "INFO: enterprise.signals.signal_base: Setting J1614-2230_Rcvr1_2_GUPPI_efac to 1.0636501302858106\n",
+      "INFO: enterprise.signals.signal_base: Setting J1614-2230_Rcvr_800_GASP_efac to 0.9178765720365575\n",
+      "INFO: enterprise.signals.signal_base: Setting J1614-2230_Rcvr_800_GUPPI_efac to 1.0115241685032286\n",
+      "INFO: enterprise.signals.signal_base: Setting J1614-2230_Rcvr1_2_GASP_log10_equad to -7.32067533880299\n",
+      "INFO: enterprise.signals.signal_base: Setting J1614-2230_Rcvr1_2_GUPPI_log10_equad to -7.784678758801305\n",
+      "INFO: enterprise.signals.signal_base: Setting J1614-2230_Rcvr_800_GASP_log10_equad to -7.2577825388006305\n",
+      "INFO: enterprise.signals.signal_base: Setting J1614-2230_Rcvr_800_GUPPI_log10_equad to -7.627864180562532\n",
+      "INFO: enterprise.signals.signal_base: Setting J1614-2230_Rcvr1_2_GASP_log10_ecorr to -7.448625358285439\n",
+      "INFO: enterprise.signals.signal_base: Setting J1614-2230_Rcvr1_2_GUPPI_log10_ecorr to -7.655859629011535\n",
+      "INFO: enterprise.signals.signal_base: Setting J1614-2230_Rcvr_800_GASP_log10_ecorr to -7.299611199085039\n",
+      "INFO: enterprise.signals.signal_base: Setting J1614-2230_Rcvr_800_GUPPI_log10_ecorr to -7.4080289590963355\n",
+      "INFO: enterprise.signals.signal_base: Setting J1640+2224_430_ASP_efac to 1.143081359459332\n",
+      "INFO: enterprise.signals.signal_base: Setting J1640+2224_430_PUPPI_efac to 1.0573767076899483\n",
+      "INFO: enterprise.signals.signal_base: Setting J1640+2224_L-wide_ASP_efac to 1.06394287552814\n",
+      "INFO: enterprise.signals.signal_base: Setting J1640+2224_L-wide_PUPPI_efac to 1.1457585235526273\n",
+      "INFO: enterprise.signals.signal_base: Setting J1640+2224_430_ASP_log10_equad to -6.240784825369144\n",
+      "INFO: enterprise.signals.signal_base: Setting J1640+2224_430_PUPPI_log10_equad to -6.9445789284154085\n",
+      "INFO: enterprise.signals.signal_base: Setting J1640+2224_L-wide_ASP_log10_equad to -7.649274979312211\n",
+      "INFO: enterprise.signals.signal_base: Setting J1640+2224_L-wide_PUPPI_log10_equad to -8.075008065199082\n",
+      "INFO: enterprise.signals.signal_base: Setting J1640+2224_430_ASP_log10_ecorr to -7.788811673814794\n",
+      "INFO: enterprise.signals.signal_base: Setting J1640+2224_430_PUPPI_log10_ecorr to -6.901622491949263\n",
+      "INFO: enterprise.signals.signal_base: Setting J1640+2224_L-wide_ASP_log10_ecorr to -6.275572665649051\n",
+      "INFO: enterprise.signals.signal_base: Setting J1640+2224_L-wide_PUPPI_log10_ecorr to -6.4079933035010095\n",
+      "INFO: enterprise.signals.signal_base: Setting J1643-1224_Rcvr1_2_GASP_efac to 1.0071858015273707\n",
+      "INFO: enterprise.signals.signal_base: Setting J1643-1224_Rcvr1_2_GUPPI_efac to 1.1247022811624827\n",
+      "INFO: enterprise.signals.signal_base: Setting J1643-1224_Rcvr_800_GASP_efac to 1.493816799359807\n",
+      "INFO: enterprise.signals.signal_base: Setting J1643-1224_Rcvr_800_GUPPI_efac to 1.1921609687505945\n",
+      "INFO: enterprise.signals.signal_base: Setting J1643-1224_Rcvr1_2_GASP_log10_equad to -7.277156122921472\n",
+      "INFO: enterprise.signals.signal_base: Setting J1643-1224_Rcvr1_2_GUPPI_log10_equad to -7.138128067645691\n",
+      "INFO: enterprise.signals.signal_base: Setting J1643-1224_Rcvr_800_GASP_log10_equad to -7.115627957850879\n",
+      "INFO: enterprise.signals.signal_base: Setting J1643-1224_Rcvr_800_GUPPI_log10_equad to -5.9780473533853655\n",
+      "INFO: enterprise.signals.signal_base: Setting J1643-1224_Rcvr1_2_GASP_log10_ecorr to -7.503311141343279\n",
+      "INFO: enterprise.signals.signal_base: Setting J1643-1224_Rcvr1_2_GUPPI_log10_ecorr to -6.042898081068246\n",
+      "INFO: enterprise.signals.signal_base: Setting J1643-1224_Rcvr_800_GASP_log10_ecorr to -6.822037374515338\n",
+      "INFO: enterprise.signals.signal_base: Setting J1643-1224_Rcvr_800_GUPPI_log10_ecorr to -5.544475232494147\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_L-wide_ASP_efac to 1.0524302344416032\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_L-wide_PUPPI_efac to 0.9796026604137508\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_Rcvr1_2_GASP_efac to 1.084307149708116\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_Rcvr1_2_GUPPI_efac to 1.017213088587959\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_Rcvr_800_GASP_efac to 1.117529091199639\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_Rcvr_800_GUPPI_efac to 1.0500383710337968\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_S-wide_ASP_efac to 1.1139598766607257\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_S-wide_PUPPI_efac to 1.0889710082237398\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_L-wide_ASP_log10_equad to -7.58206720746206\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_L-wide_PUPPI_log10_equad to -8.377098873197399\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_Rcvr1_2_GASP_log10_equad to -7.423897862687164\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_Rcvr1_2_GUPPI_log10_equad to -8.357193830632392\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_Rcvr_800_GASP_log10_equad to -7.251839650442933\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_Rcvr_800_GUPPI_log10_equad to -7.614933520652966\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_S-wide_ASP_log10_equad to -8.027710747783962\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_S-wide_PUPPI_log10_equad to -8.186781270775445\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_L-wide_ASP_log10_ecorr to -7.029000061406403\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_L-wide_PUPPI_log10_ecorr to -7.142663306094692\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_Rcvr1_2_GASP_log10_ecorr to -7.299970815145262\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_Rcvr1_2_GUPPI_log10_ecorr to -7.131010248150742\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_Rcvr_800_GASP_log10_ecorr to -7.788837849013025\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_Rcvr_800_GUPPI_log10_ecorr to -6.730867845961182\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_S-wide_ASP_log10_ecorr to -6.876597410265874\n",
+      "INFO: enterprise.signals.signal_base: Setting J1713+0747_S-wide_PUPPI_log10_ecorr to -7.305157969602163\n",
+      "INFO: enterprise.signals.signal_base: Setting J1738+0333_L-wide_ASP_efac to 1.1479069042742471\n",
+      "INFO: enterprise.signals.signal_base: Setting J1738+0333_L-wide_PUPPI_efac to 1.0710506604701162\n",
+      "INFO: enterprise.signals.signal_base: Setting J1738+0333_S-wide_ASP_efac to 0.9465373677964157\n",
+      "INFO: enterprise.signals.signal_base: Setting J1738+0333_S-wide_PUPPI_efac to 0.8845264245078953\n",
+      "INFO: enterprise.signals.signal_base: Setting J1738+0333_L-wide_ASP_log10_equad to -7.579720669663646\n",
+      "INFO: enterprise.signals.signal_base: Setting J1738+0333_L-wide_PUPPI_log10_equad to -7.886362963443982\n",
+      "INFO: enterprise.signals.signal_base: Setting J1738+0333_S-wide_ASP_log10_equad to -7.565578005221636\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: enterprise.signals.signal_base: Setting J1738+0333_S-wide_PUPPI_log10_equad to -7.767394128812992\n",
+      "INFO: enterprise.signals.signal_base: Setting J1738+0333_L-wide_ASP_log10_ecorr to -7.060532309258772\n",
+      "INFO: enterprise.signals.signal_base: Setting J1738+0333_L-wide_PUPPI_log10_ecorr to -7.019786250261518\n",
+      "INFO: enterprise.signals.signal_base: Setting J1738+0333_S-wide_ASP_log10_ecorr to -7.381958762803754\n",
+      "INFO: enterprise.signals.signal_base: Setting J1738+0333_S-wide_PUPPI_log10_ecorr to -7.7411812625497936\n",
+      "INFO: enterprise.signals.signal_base: Setting J1741+1351_430_ASP_efac to 0.9244093327309052\n",
+      "INFO: enterprise.signals.signal_base: Setting J1741+1351_430_PUPPI_efac to 1.0039009232670109\n",
+      "INFO: enterprise.signals.signal_base: Setting J1741+1351_L-wide_ASP_efac to 0.9209852519797033\n",
+      "INFO: enterprise.signals.signal_base: Setting J1741+1351_L-wide_PUPPI_efac to 1.0310288270954124\n",
+      "INFO: enterprise.signals.signal_base: Setting J1741+1351_430_ASP_log10_equad to -7.009806457228215\n",
+      "INFO: enterprise.signals.signal_base: Setting J1741+1351_430_PUPPI_log10_equad to -6.482096984326702\n",
+      "INFO: enterprise.signals.signal_base: Setting J1741+1351_L-wide_ASP_log10_equad to -7.299070391601319\n",
+      "INFO: enterprise.signals.signal_base: Setting J1741+1351_L-wide_PUPPI_log10_equad to -7.965578303654515\n",
+      "INFO: enterprise.signals.signal_base: Setting J1741+1351_430_ASP_log10_ecorr to -5.5978463759617405\n",
+      "INFO: enterprise.signals.signal_base: Setting J1741+1351_430_PUPPI_log10_ecorr to -6.518135961714821\n",
+      "INFO: enterprise.signals.signal_base: Setting J1741+1351_L-wide_ASP_log10_ecorr to -7.186847507133638\n",
+      "INFO: enterprise.signals.signal_base: Setting J1741+1351_L-wide_PUPPI_log10_ecorr to -6.925186740960002\n",
+      "INFO: enterprise.signals.signal_base: Setting J1744-1134_Rcvr1_2_GASP_efac to 0.9978514871735024\n",
+      "INFO: enterprise.signals.signal_base: Setting J1744-1134_Rcvr1_2_GUPPI_efac to 1.053362947622705\n",
+      "INFO: enterprise.signals.signal_base: Setting J1744-1134_Rcvr_800_GASP_efac to 1.1285830055400954\n",
+      "INFO: enterprise.signals.signal_base: Setting J1744-1134_Rcvr_800_GUPPI_efac to 1.0350590534568576\n",
+      "INFO: enterprise.signals.signal_base: Setting J1744-1134_Rcvr1_2_GASP_log10_equad to -6.381411751584569\n",
+      "INFO: enterprise.signals.signal_base: Setting J1744-1134_Rcvr1_2_GUPPI_log10_equad to -7.003305288540264\n",
+      "INFO: enterprise.signals.signal_base: Setting J1744-1134_Rcvr_800_GASP_log10_equad to -6.4572271715342175\n",
+      "INFO: enterprise.signals.signal_base: Setting J1744-1134_Rcvr_800_GUPPI_log10_equad to -6.613992229078914\n",
+      "INFO: enterprise.signals.signal_base: Setting J1744-1134_Rcvr1_2_GASP_log10_ecorr to -6.292180076314258\n",
+      "INFO: enterprise.signals.signal_base: Setting J1744-1134_Rcvr1_2_GUPPI_log10_ecorr to -6.537490178263718\n",
+      "INFO: enterprise.signals.signal_base: Setting J1744-1134_Rcvr_800_GASP_log10_ecorr to -6.61724561091565\n",
+      "INFO: enterprise.signals.signal_base: Setting J1744-1134_Rcvr_800_GUPPI_log10_ecorr to -6.396301881001724\n",
+      "INFO: enterprise.signals.signal_base: Setting J1747-4036_Rcvr1_2_GUPPI_efac to 1.0406387784576547\n",
+      "INFO: enterprise.signals.signal_base: Setting J1747-4036_Rcvr_800_GUPPI_efac to 1.0528123550579158\n",
+      "INFO: enterprise.signals.signal_base: Setting J1747-4036_Rcvr1_2_GUPPI_log10_equad to -7.287658831864024\n",
+      "INFO: enterprise.signals.signal_base: Setting J1747-4036_Rcvr_800_GUPPI_log10_equad to -7.2659273913234985\n",
+      "INFO: enterprise.signals.signal_base: Setting J1747-4036_Rcvr1_2_GUPPI_log10_ecorr to -5.905403465022769\n",
+      "INFO: enterprise.signals.signal_base: Setting J1747-4036_Rcvr_800_GUPPI_log10_ecorr to -5.457175287447477\n",
+      "INFO: enterprise.signals.signal_base: Setting J1832-0836_Rcvr1_2_GUPPI_efac to 1.0272388771646892\n",
+      "INFO: enterprise.signals.signal_base: Setting J1832-0836_Rcvr_800_GUPPI_efac to 1.003562365688325\n",
+      "INFO: enterprise.signals.signal_base: Setting J1832-0836_Rcvr1_2_GUPPI_log10_equad to -7.588132853561516\n",
+      "INFO: enterprise.signals.signal_base: Setting J1832-0836_Rcvr_800_GUPPI_log10_equad to -6.2428519645876905\n",
+      "INFO: enterprise.signals.signal_base: Setting J1832-0836_Rcvr1_2_GUPPI_log10_ecorr to -7.648628979373505\n",
+      "INFO: enterprise.signals.signal_base: Setting J1832-0836_Rcvr_800_GUPPI_log10_ecorr to -7.3689842599211035\n",
+      "INFO: enterprise.signals.signal_base: Setting J1853+1303_430_ASP_efac to 1.078315248869886\n",
+      "INFO: enterprise.signals.signal_base: Setting J1853+1303_430_PUPPI_efac to 1.0109631461154447\n",
+      "INFO: enterprise.signals.signal_base: Setting J1853+1303_L-wide_ASP_efac to 1.0786110947865066\n",
+      "INFO: enterprise.signals.signal_base: Setting J1853+1303_L-wide_PUPPI_efac to 1.0235843088915801\n",
+      "INFO: enterprise.signals.signal_base: Setting J1853+1303_430_ASP_log10_equad to -7.0316537983149825\n",
+      "INFO: enterprise.signals.signal_base: Setting J1853+1303_430_PUPPI_log10_equad to -7.1227376684628645\n",
+      "INFO: enterprise.signals.signal_base: Setting J1853+1303_L-wide_ASP_log10_equad to -7.1547369968726455\n",
+      "INFO: enterprise.signals.signal_base: Setting J1853+1303_L-wide_PUPPI_log10_equad to -7.722036732168339\n",
+      "INFO: enterprise.signals.signal_base: Setting J1853+1303_430_ASP_log10_ecorr to -6.786182491593548\n",
+      "INFO: enterprise.signals.signal_base: Setting J1853+1303_430_PUPPI_log10_ecorr to -7.344038425120731\n",
+      "INFO: enterprise.signals.signal_base: Setting J1853+1303_L-wide_ASP_log10_ecorr to -7.0135381645815835\n",
+      "INFO: enterprise.signals.signal_base: Setting J1853+1303_L-wide_PUPPI_log10_ecorr to -7.804157398025932\n",
+      "INFO: enterprise.signals.signal_base: Setting J1903+0327_L-wide_ASP_efac to 1.179706924996803\n",
+      "INFO: enterprise.signals.signal_base: Setting J1903+0327_L-wide_PUPPI_efac to 1.168460641474899\n",
+      "INFO: enterprise.signals.signal_base: Setting J1903+0327_S-wide_ASP_efac to 0.8321334329815202\n",
+      "INFO: enterprise.signals.signal_base: Setting J1903+0327_S-wide_PUPPI_efac to 1.1095637896315254\n",
+      "INFO: enterprise.signals.signal_base: Setting J1903+0327_L-wide_ASP_log10_equad to -7.158390864212146\n",
+      "INFO: enterprise.signals.signal_base: Setting J1903+0327_L-wide_PUPPI_log10_equad to -7.759288526577286\n",
+      "INFO: enterprise.signals.signal_base: Setting J1903+0327_S-wide_ASP_log10_equad to -6.16963651015452\n",
+      "INFO: enterprise.signals.signal_base: Setting J1903+0327_S-wide_PUPPI_log10_equad to -7.574001886389685\n",
+      "INFO: enterprise.signals.signal_base: Setting J1903+0327_L-wide_ASP_log10_ecorr to -7.172149108226772\n",
+      "INFO: enterprise.signals.signal_base: Setting J1903+0327_L-wide_PUPPI_log10_ecorr to -5.636329138486162\n",
+      "INFO: enterprise.signals.signal_base: Setting J1903+0327_S-wide_ASP_log10_ecorr to -7.364742895573575\n",
+      "INFO: enterprise.signals.signal_base: Setting J1903+0327_S-wide_PUPPI_log10_ecorr to -7.45437286784459\n",
+      "INFO: enterprise.signals.signal_base: Setting J1909-3744_Rcvr1_2_GASP_efac to 0.9505606759311833\n",
+      "INFO: enterprise.signals.signal_base: Setting J1909-3744_Rcvr1_2_GUPPI_efac to 1.0339776268866265\n",
+      "INFO: enterprise.signals.signal_base: Setting J1909-3744_Rcvr_800_GASP_efac to 1.0504080629362422\n",
+      "INFO: enterprise.signals.signal_base: Setting J1909-3744_Rcvr_800_GUPPI_efac to 1.0313779800296294\n",
+      "INFO: enterprise.signals.signal_base: Setting J1909-3744_Rcvr1_2_GASP_log10_equad to -7.456278210493956\n",
+      "INFO: enterprise.signals.signal_base: Setting J1909-3744_Rcvr1_2_GUPPI_log10_equad to -8.171553179171445\n",
+      "INFO: enterprise.signals.signal_base: Setting J1909-3744_Rcvr_800_GASP_log10_equad to -7.037406290351743\n",
+      "INFO: enterprise.signals.signal_base: Setting J1909-3744_Rcvr_800_GUPPI_log10_equad to -7.365322642903795\n",
+      "INFO: enterprise.signals.signal_base: Setting J1909-3744_Rcvr1_2_GASP_log10_ecorr to -8.078816887958723\n",
+      "INFO: enterprise.signals.signal_base: Setting J1909-3744_Rcvr1_2_GUPPI_log10_ecorr to -7.137638201510413\n",
+      "INFO: enterprise.signals.signal_base: Setting J1909-3744_Rcvr_800_GASP_log10_ecorr to -7.871774784575877\n",
+      "INFO: enterprise.signals.signal_base: Setting J1909-3744_Rcvr_800_GUPPI_log10_ecorr to -7.269816370154123\n",
+      "INFO: enterprise.signals.signal_base: Setting J1910+1256_L-wide_ASP_efac to 1.063590147073229\n",
+      "INFO: enterprise.signals.signal_base: Setting J1910+1256_L-wide_PUPPI_efac to 1.0931136416030962\n",
+      "INFO: enterprise.signals.signal_base: Setting J1910+1256_S-wide_ASP_efac to 0.9661536934887565\n",
+      "INFO: enterprise.signals.signal_base: Setting J1910+1256_S-wide_PUPPI_efac to 1.0982792255110136\n",
+      "INFO: enterprise.signals.signal_base: Setting J1910+1256_L-wide_ASP_log10_equad to -7.516992859042785\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: enterprise.signals.signal_base: Setting J1910+1256_L-wide_PUPPI_log10_equad to -7.585087262800533\n",
+      "INFO: enterprise.signals.signal_base: Setting J1910+1256_S-wide_ASP_log10_equad to -6.218657154174941\n",
+      "INFO: enterprise.signals.signal_base: Setting J1910+1256_S-wide_PUPPI_log10_equad to -7.401958120896809\n",
+      "INFO: enterprise.signals.signal_base: Setting J1910+1256_L-wide_ASP_log10_ecorr to -7.259684055387137\n",
+      "INFO: enterprise.signals.signal_base: Setting J1910+1256_L-wide_PUPPI_log10_ecorr to -7.403550254322336\n",
+      "INFO: enterprise.signals.signal_base: Setting J1910+1256_S-wide_ASP_log10_ecorr to -7.195615972473434\n",
+      "INFO: enterprise.signals.signal_base: Setting J1910+1256_S-wide_PUPPI_log10_ecorr to -6.218612073150832\n",
+      "INFO: enterprise.signals.signal_base: Setting J1911+1347_430_PUPPI_efac to 0.985037691631346\n",
+      "INFO: enterprise.signals.signal_base: Setting J1911+1347_L-wide_PUPPI_efac to 1.031540153660689\n",
+      "INFO: enterprise.signals.signal_base: Setting J1911+1347_430_PUPPI_log10_equad to -6.31556161756245\n",
+      "INFO: enterprise.signals.signal_base: Setting J1911+1347_L-wide_PUPPI_log10_equad to -7.89819259988214\n",
+      "INFO: enterprise.signals.signal_base: Setting J1911+1347_430_PUPPI_log10_ecorr to -6.9556333516614375\n",
+      "INFO: enterprise.signals.signal_base: Setting J1911+1347_L-wide_PUPPI_log10_ecorr to -7.416268263053558\n",
+      "INFO: enterprise.signals.signal_base: Setting J1918-0642_Rcvr1_2_GASP_efac to 1.0272847294363423\n",
+      "INFO: enterprise.signals.signal_base: Setting J1918-0642_Rcvr1_2_GUPPI_efac to 1.035664184009173\n",
+      "INFO: enterprise.signals.signal_base: Setting J1918-0642_Rcvr_800_GASP_efac to 1.0557165923306966\n",
+      "INFO: enterprise.signals.signal_base: Setting J1918-0642_Rcvr_800_GUPPI_efac to 1.034910727323206\n",
+      "INFO: enterprise.signals.signal_base: Setting J1918-0642_Rcvr1_2_GASP_log10_equad to -7.67322161371427\n",
+      "INFO: enterprise.signals.signal_base: Setting J1918-0642_Rcvr1_2_GUPPI_log10_equad to -7.3696863188027075\n",
+      "INFO: enterprise.signals.signal_base: Setting J1918-0642_Rcvr_800_GASP_log10_equad to -7.105797415440444\n",
+      "INFO: enterprise.signals.signal_base: Setting J1918-0642_Rcvr_800_GUPPI_log10_equad to -7.086564536955872\n",
+      "INFO: enterprise.signals.signal_base: Setting J1918-0642_Rcvr1_2_GASP_log10_ecorr to -7.37828526123227\n",
+      "INFO: enterprise.signals.signal_base: Setting J1918-0642_Rcvr1_2_GUPPI_log10_ecorr to -7.4935011859866485\n",
+      "INFO: enterprise.signals.signal_base: Setting J1918-0642_Rcvr_800_GASP_log10_ecorr to -7.559243560441317\n",
+      "INFO: enterprise.signals.signal_base: Setting J1918-0642_Rcvr_800_GUPPI_log10_ecorr to -6.525389492066881\n",
+      "INFO: enterprise.signals.signal_base: Setting J1923+2515_430_ASP_efac to 1.2373635265106926\n",
+      "INFO: enterprise.signals.signal_base: Setting J1923+2515_430_PUPPI_efac to 1.0280076337777575\n",
+      "INFO: enterprise.signals.signal_base: Setting J1923+2515_L-wide_ASP_efac to 0.9386238008730015\n",
+      "INFO: enterprise.signals.signal_base: Setting J1923+2515_L-wide_PUPPI_efac to 1.144937414850767\n",
+      "INFO: enterprise.signals.signal_base: Setting J1923+2515_430_ASP_log10_equad to -7.142953738975613\n",
+      "INFO: enterprise.signals.signal_base: Setting J1923+2515_430_PUPPI_log10_equad to -7.497964593513206\n",
+      "INFO: enterprise.signals.signal_base: Setting J1923+2515_L-wide_ASP_log10_equad to -7.5494203338472525\n",
+      "INFO: enterprise.signals.signal_base: Setting J1923+2515_L-wide_PUPPI_log10_equad to -7.726627359060009\n",
+      "INFO: enterprise.signals.signal_base: Setting J1923+2515_430_ASP_log10_ecorr to -6.504184743324717\n",
+      "INFO: enterprise.signals.signal_base: Setting J1923+2515_430_PUPPI_log10_ecorr to -7.011533421266852\n",
+      "INFO: enterprise.signals.signal_base: Setting J1923+2515_L-wide_ASP_log10_ecorr to -6.546436794429655\n",
+      "INFO: enterprise.signals.signal_base: Setting J1923+2515_L-wide_PUPPI_log10_ecorr to -7.532279133666613\n",
+      "INFO: enterprise.signals.signal_base: Setting J1944+0907_430_ASP_efac to 1.0814498126291534\n",
+      "INFO: enterprise.signals.signal_base: Setting J1944+0907_430_PUPPI_efac to 1.0727024023469869\n",
+      "INFO: enterprise.signals.signal_base: Setting J1944+0907_L-wide_ASP_efac to 1.5390588569396464\n",
+      "INFO: enterprise.signals.signal_base: Setting J1944+0907_L-wide_PUPPI_efac to 1.1696155596603073\n",
+      "INFO: enterprise.signals.signal_base: Setting J1944+0907_430_ASP_log10_equad to -7.243114059446985\n",
+      "INFO: enterprise.signals.signal_base: Setting J1944+0907_430_PUPPI_log10_equad to -6.926315089238918\n",
+      "INFO: enterprise.signals.signal_base: Setting J1944+0907_L-wide_ASP_log10_equad to -7.238241222764401\n",
+      "INFO: enterprise.signals.signal_base: Setting J1944+0907_L-wide_PUPPI_log10_equad to -7.693354205218862\n",
+      "INFO: enterprise.signals.signal_base: Setting J1944+0907_430_ASP_log10_ecorr to -6.8879174105358185\n",
+      "INFO: enterprise.signals.signal_base: Setting J1944+0907_430_PUPPI_log10_ecorr to -7.1306299212575945\n",
+      "INFO: enterprise.signals.signal_base: Setting J1944+0907_L-wide_ASP_log10_ecorr to -7.104483772896318\n",
+      "INFO: enterprise.signals.signal_base: Setting J1944+0907_L-wide_PUPPI_log10_ecorr to -6.546284570029579\n",
+      "INFO: enterprise.signals.signal_base: Setting J2010-1323_Rcvr1_2_GASP_efac to 1.0179865222180375\n",
+      "INFO: enterprise.signals.signal_base: Setting J2010-1323_Rcvr1_2_GUPPI_efac to 1.046213434079912\n",
+      "INFO: enterprise.signals.signal_base: Setting J2010-1323_Rcvr_800_GASP_efac to 1.0631310225900652\n",
+      "INFO: enterprise.signals.signal_base: Setting J2010-1323_Rcvr_800_GUPPI_efac to 0.9946706739052781\n",
+      "INFO: enterprise.signals.signal_base: Setting J2010-1323_Rcvr1_2_GASP_log10_equad to -7.170459137166772\n",
+      "INFO: enterprise.signals.signal_base: Setting J2010-1323_Rcvr1_2_GUPPI_log10_equad to -7.676454828722258\n",
+      "INFO: enterprise.signals.signal_base: Setting J2010-1323_Rcvr_800_GASP_log10_equad to -7.260685669109653\n",
+      "INFO: enterprise.signals.signal_base: Setting J2010-1323_Rcvr_800_GUPPI_log10_equad to -7.2177759208361\n",
+      "INFO: enterprise.signals.signal_base: Setting J2010-1323_Rcvr1_2_GASP_log10_ecorr to -7.182315425909628\n",
+      "INFO: enterprise.signals.signal_base: Setting J2010-1323_Rcvr1_2_GUPPI_log10_ecorr to -7.686560497366312\n",
+      "INFO: enterprise.signals.signal_base: Setting J2010-1323_Rcvr_800_GASP_log10_ecorr to -7.241412604014393\n",
+      "INFO: enterprise.signals.signal_base: Setting J2010-1323_Rcvr_800_GUPPI_log10_ecorr to -7.580143294343043\n",
+      "INFO: enterprise.signals.signal_base: Setting J2017+0603_430_PUPPI_efac to 1.0093822233123215\n",
+      "INFO: enterprise.signals.signal_base: Setting J2017+0603_L-wide_ASP_efac to 1.1836322124322396\n",
+      "INFO: enterprise.signals.signal_base: Setting J2017+0603_L-wide_PUPPI_efac to 1.046323313584208\n",
+      "INFO: enterprise.signals.signal_base: Setting J2017+0603_S-wide_ASP_efac to 1.8932930007480588\n",
+      "INFO: enterprise.signals.signal_base: Setting J2017+0603_S-wide_PUPPI_efac to 0.9637488192067073\n",
+      "INFO: enterprise.signals.signal_base: Setting J2017+0603_430_PUPPI_log10_equad to -7.400340554989067\n",
+      "INFO: enterprise.signals.signal_base: Setting J2017+0603_L-wide_ASP_log10_equad to -7.367283946930043\n",
+      "INFO: enterprise.signals.signal_base: Setting J2017+0603_L-wide_PUPPI_log10_equad to -7.912206252778333\n",
+      "INFO: enterprise.signals.signal_base: Setting J2017+0603_S-wide_ASP_log10_equad to -6.873558567695128\n",
+      "INFO: enterprise.signals.signal_base: Setting J2017+0603_S-wide_PUPPI_log10_equad to -7.597464103922708\n",
+      "INFO: enterprise.signals.signal_base: Setting J2017+0603_430_PUPPI_log10_ecorr to -7.128447031828422\n",
+      "INFO: enterprise.signals.signal_base: Setting J2017+0603_L-wide_ASP_log10_ecorr to -7.173248610617583\n",
+      "INFO: enterprise.signals.signal_base: Setting J2017+0603_L-wide_PUPPI_log10_ecorr to -7.82755132699267\n",
+      "INFO: enterprise.signals.signal_base: Setting J2017+0603_S-wide_ASP_log10_ecorr to -6.789428630198219\n",
+      "INFO: enterprise.signals.signal_base: Setting J2017+0603_S-wide_PUPPI_log10_ecorr to -7.6940668965722345\n",
+      "INFO: enterprise.signals.signal_base: Setting J2033+1734_430_PUPPI_efac to 1.113693949200785\n",
+      "INFO: enterprise.signals.signal_base: Setting J2033+1734_L-wide_PUPPI_efac to 1.1331427517539416\n",
+      "INFO: enterprise.signals.signal_base: Setting J2033+1734_430_PUPPI_log10_equad to -5.6337162471402555\n",
+      "INFO: enterprise.signals.signal_base: Setting J2033+1734_L-wide_PUPPI_log10_equad to -5.847707336563429\n",
+      "INFO: enterprise.signals.signal_base: Setting J2033+1734_430_PUPPI_log10_ecorr to -5.726283991030456\n",
+      "INFO: enterprise.signals.signal_base: Setting J2033+1734_L-wide_PUPPI_log10_ecorr to -6.971693370311569\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: enterprise.signals.signal_base: Setting J2043+1711_430_ASP_efac to 1.3778492919774936\n",
+      "INFO: enterprise.signals.signal_base: Setting J2043+1711_430_PUPPI_efac to 1.0512309919631644\n",
+      "INFO: enterprise.signals.signal_base: Setting J2043+1711_L-wide_ASP_efac to 1.1374179552758532\n",
+      "INFO: enterprise.signals.signal_base: Setting J2043+1711_L-wide_PUPPI_efac to 0.9994555465027908\n",
+      "INFO: enterprise.signals.signal_base: Setting J2043+1711_430_ASP_log10_equad to -7.4422502879843595\n",
+      "INFO: enterprise.signals.signal_base: Setting J2043+1711_430_PUPPI_log10_equad to -6.713932912210494\n",
+      "INFO: enterprise.signals.signal_base: Setting J2043+1711_L-wide_ASP_log10_equad to -7.464474830386383\n",
+      "INFO: enterprise.signals.signal_base: Setting J2043+1711_L-wide_PUPPI_log10_equad to -8.072882690972005\n",
+      "INFO: enterprise.signals.signal_base: Setting J2043+1711_430_ASP_log10_ecorr to -7.239541093300854\n",
+      "INFO: enterprise.signals.signal_base: Setting J2043+1711_430_PUPPI_log10_ecorr to -7.421485674442805\n",
+      "INFO: enterprise.signals.signal_base: Setting J2043+1711_L-wide_ASP_log10_ecorr to -7.396188335081211\n",
+      "INFO: enterprise.signals.signal_base: Setting J2043+1711_L-wide_PUPPI_log10_ecorr to -7.5041112226693665\n",
+      "INFO: enterprise.signals.signal_base: Setting J2145-0750_Rcvr1_2_GASP_efac to 1.0110230422869044\n",
+      "INFO: enterprise.signals.signal_base: Setting J2145-0750_Rcvr1_2_GUPPI_efac to 1.0265447460207069\n",
+      "INFO: enterprise.signals.signal_base: Setting J2145-0750_Rcvr_800_GASP_efac to 1.2601984171075302\n",
+      "INFO: enterprise.signals.signal_base: Setting J2145-0750_Rcvr_800_GUPPI_efac to 1.0476740581711277\n",
+      "INFO: enterprise.signals.signal_base: Setting J2145-0750_Rcvr1_2_GASP_log10_equad to -5.705026109830131\n",
+      "INFO: enterprise.signals.signal_base: Setting J2145-0750_Rcvr1_2_GUPPI_log10_equad to -7.938817552005569\n",
+      "INFO: enterprise.signals.signal_base: Setting J2145-0750_Rcvr_800_GASP_log10_equad to -6.513203859186709\n",
+      "INFO: enterprise.signals.signal_base: Setting J2145-0750_Rcvr_800_GUPPI_log10_equad to -6.4184191843741445\n",
+      "INFO: enterprise.signals.signal_base: Setting J2145-0750_Rcvr1_2_GASP_log10_ecorr to -6.243824665782128\n",
+      "INFO: enterprise.signals.signal_base: Setting J2145-0750_Rcvr1_2_GUPPI_log10_ecorr to -6.355906738653193\n",
+      "INFO: enterprise.signals.signal_base: Setting J2145-0750_Rcvr_800_GASP_log10_ecorr to -6.233581141499856\n",
+      "INFO: enterprise.signals.signal_base: Setting J2145-0750_Rcvr_800_GUPPI_log10_ecorr to -6.598154829313346\n",
+      "INFO: enterprise.signals.signal_base: Setting J2214+3000_L-wide_ASP_efac to 0.8328153450864979\n",
+      "INFO: enterprise.signals.signal_base: Setting J2214+3000_L-wide_PUPPI_efac to 1.1954220361348742\n",
+      "INFO: enterprise.signals.signal_base: Setting J2214+3000_S-wide_ASP_efac to 0.9594843801019013\n",
+      "INFO: enterprise.signals.signal_base: Setting J2214+3000_S-wide_PUPPI_efac to 1.093500299806876\n",
+      "INFO: enterprise.signals.signal_base: Setting J2214+3000_L-wide_ASP_log10_equad to -6.458067613616678\n",
+      "INFO: enterprise.signals.signal_base: Setting J2214+3000_L-wide_PUPPI_log10_equad to -7.774691520862171\n",
+      "INFO: enterprise.signals.signal_base: Setting J2214+3000_S-wide_ASP_log10_equad to -6.629799719267349\n",
+      "INFO: enterprise.signals.signal_base: Setting J2214+3000_S-wide_PUPPI_log10_equad to -6.42653058535195\n",
+      "INFO: enterprise.signals.signal_base: Setting J2214+3000_L-wide_ASP_log10_ecorr to -7.064223052679033\n",
+      "INFO: enterprise.signals.signal_base: Setting J2214+3000_L-wide_PUPPI_log10_ecorr to -6.843650772362196\n",
+      "INFO: enterprise.signals.signal_base: Setting J2214+3000_S-wide_ASP_log10_ecorr to -6.982471151348989\n",
+      "INFO: enterprise.signals.signal_base: Setting J2214+3000_S-wide_PUPPI_log10_ecorr to -6.006076849471581\n",
+      "INFO: enterprise.signals.signal_base: Setting J2229+2643_430_PUPPI_efac to 1.081340003095888\n",
+      "INFO: enterprise.signals.signal_base: Setting J2229+2643_L-wide_PUPPI_efac to 1.1795637381251032\n",
+      "INFO: enterprise.signals.signal_base: Setting J2229+2643_430_PUPPI_log10_equad to -6.246045309208485\n",
+      "INFO: enterprise.signals.signal_base: Setting J2229+2643_L-wide_PUPPI_log10_equad to -7.72877475370162\n",
+      "INFO: enterprise.signals.signal_base: Setting J2229+2643_430_PUPPI_log10_ecorr to -7.16659104160414\n",
+      "INFO: enterprise.signals.signal_base: Setting J2229+2643_L-wide_PUPPI_log10_ecorr to -7.630859344308238\n",
+      "INFO: enterprise.signals.signal_base: Setting J2234+0611_430_PUPPI_efac to 1.0168457574856116\n",
+      "INFO: enterprise.signals.signal_base: Setting J2234+0611_L-wide_PUPPI_efac to 1.0185619088869677\n",
+      "INFO: enterprise.signals.signal_base: Setting J2234+0611_430_PUPPI_log10_equad to -7.144484089842051\n",
+      "INFO: enterprise.signals.signal_base: Setting J2234+0611_L-wide_PUPPI_log10_equad to -7.986093958197549\n",
+      "INFO: enterprise.signals.signal_base: Setting J2234+0611_430_PUPPI_log10_ecorr to -7.178480567640888\n",
+      "INFO: enterprise.signals.signal_base: Setting J2234+0611_L-wide_PUPPI_log10_ecorr to -7.741037555501858\n",
+      "INFO: enterprise.signals.signal_base: Setting J2234+0944_L-wide_PUPPI_efac to 1.1886958995544086\n",
+      "INFO: enterprise.signals.signal_base: Setting J2234+0944_S-wide_PUPPI_efac to 1.1493789577948121\n",
+      "INFO: enterprise.signals.signal_base: Setting J2234+0944_L-wide_PUPPI_log10_equad to -8.01966073470603\n",
+      "INFO: enterprise.signals.signal_base: Setting J2234+0944_S-wide_PUPPI_log10_equad to -7.4668410598173764\n",
+      "INFO: enterprise.signals.signal_base: Setting J2234+0944_L-wide_PUPPI_log10_ecorr to -7.324102061099362\n",
+      "INFO: enterprise.signals.signal_base: Setting J2234+0944_S-wide_PUPPI_log10_ecorr to -7.687736605464814\n",
+      "INFO: enterprise.signals.signal_base: Setting J2302+4442_Rcvr1_2_GUPPI_efac to 1.101236202155907\n",
+      "INFO: enterprise.signals.signal_base: Setting J2302+4442_Rcvr_800_GUPPI_efac to 1.0112433105873015\n",
+      "INFO: enterprise.signals.signal_base: Setting J2302+4442_Rcvr1_2_GUPPI_log10_equad to -7.467215637393752\n",
+      "INFO: enterprise.signals.signal_base: Setting J2302+4442_Rcvr_800_GUPPI_log10_equad to -7.235383029096117\n",
+      "INFO: enterprise.signals.signal_base: Setting J2302+4442_Rcvr1_2_GUPPI_log10_ecorr to -7.404814234661835\n",
+      "INFO: enterprise.signals.signal_base: Setting J2302+4442_Rcvr_800_GUPPI_log10_ecorr to -6.220143740762793\n",
+      "INFO: enterprise.signals.signal_base: Setting J2317+1439_327_ASP_efac to 1.0823722500112272\n",
+      "INFO: enterprise.signals.signal_base: Setting J2317+1439_327_PUPPI_efac to 1.17384139990156\n",
+      "INFO: enterprise.signals.signal_base: Setting J2317+1439_430_ASP_efac to 1.2574511773494976\n",
+      "INFO: enterprise.signals.signal_base: Setting J2317+1439_430_PUPPI_efac to 1.0163851726761812\n",
+      "INFO: enterprise.signals.signal_base: Setting J2317+1439_L-wide_PUPPI_efac to 1.1163982326548925\n",
+      "INFO: enterprise.signals.signal_base: Setting J2317+1439_327_ASP_log10_equad to -6.457911273619141\n",
+      "INFO: enterprise.signals.signal_base: Setting J2317+1439_327_PUPPI_log10_equad to -6.462306002360743\n",
+      "INFO: enterprise.signals.signal_base: Setting J2317+1439_430_ASP_log10_equad to -7.3732139102446626\n",
+      "INFO: enterprise.signals.signal_base: Setting J2317+1439_430_PUPPI_log10_equad to -6.535705196682452\n",
+      "INFO: enterprise.signals.signal_base: Setting J2317+1439_L-wide_PUPPI_log10_equad to -7.463944437178126\n",
+      "INFO: enterprise.signals.signal_base: Setting J2317+1439_327_ASP_log10_ecorr to -7.706187896212512\n",
+      "INFO: enterprise.signals.signal_base: Setting J2317+1439_327_PUPPI_log10_ecorr to -6.392284847303101\n",
+      "INFO: enterprise.signals.signal_base: Setting J2317+1439_430_ASP_log10_ecorr to -6.509624616624109\n",
+      "INFO: enterprise.signals.signal_base: Setting J2317+1439_430_PUPPI_log10_ecorr to -6.87918040058842\n",
+      "INFO: enterprise.signals.signal_base: Setting J2317+1439_L-wide_PUPPI_log10_ecorr to -6.6463560361584975\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 4min 54s, sys: 1.36 s, total: 4min 55s\n",
+      "Wall time: 4min 55s\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
+    "# (Note: It may take a few minutes to run this cell and may require at least ~4GB RAM)\n",
     "# Initialize the optimal statistic object\n",
     "# You can give it a list of pulsars and the noise dictionary, and it will create the pta object for you\n",
     "# Alternatively, you can make the pta object yourself and give it to the OptimalStatistic object as an argument\n",
@@ -103,12 +662,14 @@
     "# We need to set the white noise parameters to the values in the noise dictionary\n",
     "pta.set_default_params(noisedict)\n",
     "\n",
-    "os = opt_stat.OptimalStatistic(psrs, pta=pta)"
+    "os = opt_stat.OptimalStatistic(psrs, pta=pta, orf='hd')\n",
+    "os_dip = opt_stat.OptimalStatistic(psrs, pta=pta, orf='dipole')\n",
+    "os_mono = opt_stat.OptimalStatistic(psrs, pta=pta, orf='monopole')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,15 +678,33 @@
     "# Once you have done your own Bayesian search, \n",
     "# you can make your own parameter dictionary of maximum-likelihood values\n",
     "\n",
-    "with open('data/12p5yr_maxlike.json', 'r') as f:\n",
+    "with open('../data/12p5yr_maxlike.json', 'r') as f:\n",
+    "#with open('../data/12p5yr_median.json', 'r') as f:\n",
     "    ml_params = json.load(f)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
+   "source": [
+    "## Optimal statistics with maximum likelihood noise parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4.1055830307440316e-30 1.5284399015615437e-30 2.6861265703345794\n",
+      "9.14577581829387e-31 3.999316940779174e-31 2.2868344654154935\n",
+      "8.728806262383869e-31 2.730611816680664e-31 3.1966485346110525\n"
+     ]
+    }
+   ],
    "source": [
     "# Compute the optimal statistic\n",
     "# The optimal statistic returns five quantities:\n",
@@ -136,12 +715,18 @@
     "#  - OS_sig: the uncertainty in the optimal statistic\n",
     "\n",
     "xi, rho, sig, OS, OS_sig = os.compute_os(params=ml_params)\n",
-    "print(OS, OS_sig, OS/OS_sig)"
+    "print(OS, OS_sig, OS/OS_sig)\n",
+    "\n",
+    "_, _, _, OS_dip, OS_sig_dip = os_dip.compute_os(params=ml_params)\n",
+    "print(OS_dip, OS_sig_dip, OS_dip/OS_sig_dip)\n",
+    "\n",
+    "_, _, _, OS_mono, OS_sig_mono = os_mono.compute_os(params=ml_params)\n",
+    "print(OS_mono, OS_sig_mono, OS_mono/OS_sig_mono)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +789,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,12 +803,32 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# now make the plot\n",
+    "## Figure 5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAagAAAEYCAYAAAAJeGK1AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/d3fzzAAAACXBIWXMAAAsTAAALEwEAmpwYAABJfklEQVR4nO3deVzUdf7A8ddnhmu4kUPk8L4PVMD7rNQsTNPKsmwtO7Z+m1upa7XultW6bW5a22VZbbkdlqVdWl6VaeUFHnjfiqAo4s0hx3x+f8wwgQKCDMwXeD97zKP5nvOeQXjP51Zaa4QQQgijMbk6ACGEEKI0kqCEEEIYkiQoIYQQhiQJSgghhCFJghJCCGFIkqCEEEIYUp1LUEqp/yqlTiiltjnhXk2UUklKqc1Kqe1KqYeKHWumlFqnlNqrlPpMKeVR1dcTQgjxuzqXoIAPgKFOutcxoLfWugvQA3hSKRVhP/Yi8LLWuhVwGrjPSa8phBCCOpigtNargFPF9ymlWiillthLQ6uVUm0reK88rfVF+6Yn9s9LKaWAa4Ev7MfmAjc7I34hhBA2dS5BlWEOMEFrHQdMBt6s6IVKqWilVDJwBHhRa30UCAbOaK0L7KelApFOjlkIIeo1N1cHUN2UUr5Ab+BzW8EHsJWGUEqNAp4r5bI0rfX1AFrrI0CMvWrvK6XUF4C1lGtkzighhHCiOp+gsJUSz9jbkUrQWi8EFlbkJlrro0qp7UA/YAEQqJRys5eiooCjzgtZCCFEna/i01qfAw4qpW4DW/uRUqpzRa5VSkUppSz250FAH2C3ts2w+xNwq/3UccDXTg9eCCHqMVXXZjNXSs0DBgIhwHHgGeBHYDbQCHAHPtVal1a1d+m9BgMzsVXfKeB1rfUc+7HmwKdAA2ATMLZYhwohhBBVVOcSlBBCiLqhzlfxCSGEqJ3qVCeJkJAQ3bRpU1eHIYQQAkhKSjqptQ692uvrVIJq2rQpiYmJrg5DCCEEoJQ6XJXrpYpPCCGEIUmCEkIIYUiSoIQQdc7MmTOJjIws8zFz5kxXhygqoE51M4+Pj9fSBiWEKC49PZ24uDiSkpIIDw93dTj1ilIqSWsdf7XXSwlKCCGEIUmCEkIIYUiSoIQQQhiSJCghhBCGJAlKCCGEIUmCEkIIYUiSoIQQQhiSoROUUspLKbVeKbVFKbVdKfWsq2MSQghRM4w+WexF4Fqt9QWllDvwi1Lqe631WlcHJoQQonoZOkHZl1a/YN90tz/qztQXQgghymToKj4ApZRZKbUZOAEs11qvu+T4g0qpRKVUYkZGhktiFEII4XyGT1Ba60KtdRcgCuiulOp4yfE5Wut4rXV8aOhVr4slhBDCYAyfoIporc8AK4Ghro1ECCFETTB0glJKhSqlAu3PLcAgYJdLgxJCCFEjDN1JAmgEzFVKmbEl0/la60UujkkIIUQNMHSC0lonA11dHYcQQoiaZ+gqPiGEEPWXJCghhBCGJAlK1CkzZ84kMjKyzMfMmTNdHaIQooIM3QYlRGVNmjSJSZMmAZCenk5cXBxJSUmEh4e7ODIhRGVJCUoIIYQhSYISQghhSJKghBBCGJIkKIOTRn8hRH0lnSQMThr9hRD1lZSghBBCGJIkKCGEEIYkCaoGSDuSEEJUnrRBlWHmzJnMmjWrzOMTJ050tA1dibQjCSFE5UmCKoMkFVEfOPOLmBDOJglKiHpMvogJI5M2KCGEEIYkCUoIIYQhSYISQghhSJKghBBCGJIkqDpMxl8JIWozSVB12KRJk0hLSyMtLY2kpCQAkpKSHPuk+7CozarrC5Z8cTMOSVBCiFqpvPFbRRYuXEhCQgIACQkJLFy40Cn3FTXD0AlKKRWtlPpJKbVTKbVdKfWoq2MSQtQOCxcuZMqUKaSnpwO2cV5TpkypUJISxmD0gboFwCSt9UallB+QpJRarrXeUdrJp7Ly+HR9CjFRgbRu6Iub2dD5VwhRRUXJpzTTp08nJyenxL6cnBymT59O7969qzu0qyaze/zO0AlKa30MOGZ/fl4ptROIBEpNUJlZeTy5cCsAXu4mejYPZnR8NDd2alRTIQshalBcXFylrymaMcOoZHaP3xk6QRWnlGoKdAXWlXVOqzBfPp88kOTUM2xKOcPyHcdZsz+TGzs1QmvNb/sz6dU8GJNJ1VjcQojqU9T5pzQJCQmllrDCw8NZvHhxmdcZOXnVN7UiQSmlfIEFwGNa63OXHHsQeBCgcePGNAvxoVmIDyO6RPLMTe3JyS8EYN3BU9z17jqaBHszrldTbouPws/LvabfihD1Qk1VU5VXqpg6dSpTpkwpUc1nsViYOnVqvSyN1EaGb6RRSrljS04fa60va93UWs/RWsdrreNDQ0MvvRZvD1sOjmsSxGtjuhLi68lzi3bQ518/8toPe8nJK6yJtyFEvWKEIQ6jRo1ixowZjmQUHh7OjBkzGDVqVLW/tnAOQ5eglFIKeA/YqbWuUt9Pd7OJmzpHcFPnCLYcOcNrP+7lo3WHeaB/c+cEK4SoURMnTrziOaNGjaJ3797ExcWxePHiCpWcKnJfUTOMXoLqA9wNXKuU2mx/3FjVm3aODuTdcd1Y+lh/vNzN5BVYufOdtXy9OQ2tddWjFkJUu+oqhdWXHnK1gaFLUFrrX4Bq69EQ6O0BwInzuZzNyefRTzcz97dDPHNTBzpHB1bXywohhKgAo5egakRUkDffPNKXF2/pRMqpbG5+81ee/nobufnSPlVbVGZ6GpnKRojaQRKUndmkuL1bY36aPJBxvZqSnHoWdxnoW2tc2mOsvCluZCobIWoHQ1fxuYKflzvThncgr8CK2aQ4lZXH88sOgZefq0MTFVQ0xU1R9+KiKW4A6cElRC0iRYQyeLjZPpotR86wfPcp3G56lhV7Trk4KlGe9PR00tPTy53iprypcYQQxiIJ6gquaRvG3LvaoS9k8LfvDvKnjzdyOiuvRl67Im0l0p7yu7i4OOLi4spMQkaf4kYIUZIkqApo1sBC4ZIX+b8+kSzbkc7073bWyOsWbyspq01F2lN+l5SUVO6cZeHh4eVOjSOEMBZpg6oobeUP3cJJiGtGmJ8XACcvXMTPyw1PN3O1vnR5bSrOVptnUi5KTDLFjRB1gySoSuoQEQCA1pr/+2gjFy4W8PqdXWke6lstr3elNhVnq+pMykZIcEUdIYranMLDw5k6dap0kBCilpEqPq6uHUcpxR8HNOfY2RyGvfYLD0x/pxoi44ptKkbjqjnYLp2eZtSoUY4ZqxcvXlwiOclUNkLUDpKgKL8dp7zxNNe1a8h3j/ajY2QAy89HMGn+FrIuFjg1tiu1qZSlvnWwqEziM2oVpRCiJElQ5ajIktGNAix8cn8PCrd8y6Yjp7E6eS6/ouopi8VSYn9Rm0pZpINF3TVz5kwiIyPLfNSlLx6ifpM2KLvSqssqs2S0NflbvvvmDbzczeTmF7JqTwZDOjinQb68NpUJEyaUe21NdrAQNUNWXBX1hSQou8qMjylrPI2Xu6033//WHOKf3+3izh6Neeam9rz+n1fKrVaaOXNmqceLt5WUtWxAee0pNd3BQgghnEmq+OyKxtAUf1xpPE3xR3Hj+zTjoQEt+GRdCqPfWsOstz4AKl/VVpG2kvLOqW0dLIQQojgpQdmVloyudjyNm9nEkze0JbZxIJPmb8Et4W/8+63/8fZLz9VoVVtSUhIJCQmlJqPw8HBJUkIIQ5MSVDmqumT0kA7hfP1IH/S5dD5++5Uar2q72g4WQghhBJKgKL8dp7zxNBW5R/NQXwqXziDjxPFSj1d3KaaqSVYIIVxFEhTOGRdzpXtczVimqri0g0VpSVYGrAohjEwSVA0prarNw9Or2qraqtrBQgghXE06SdSQS8cyufsHU9DpZk4Ed3ZxZEIIYUxSgqoBRVVpxavafl6+hDtH30qbcD+pahNCiFJICaoGlFaV5ulm4sVbYwC4ps0k5iceIbZxIC3DZGl5IYQAKUEZwoWLBby0dDc3v/EbK3aU3ttPCGeq7Hx9Mr+fcAVDJyil1H+VUieUUttcHUt18vV046s/9aFZiA/3/y+R/6zYi9Xq3ElnhSju0tlLypu1v7TzhagJhk5QwAfAUFcHURMiAi18/lAvRnaN5OUVe/jTJxvRTp4ZXYjSVGTWflF5Rix1Xk1MWmuyLhZw9EwOO4+dY/3BU46/TUmHT/HxusPM/e0Q764+wNs/7+edVQecFq+h26C01quUUk1dHUdN8XI3M2t0ZzpGBqC1Rinl6pBEHVaUkCoza7+ouFmzZlVpKMfChQsdM80kJCQ4ZVXoS2PKzS8k9XQOR05nk342l2Nnc0k/m8MzN3XAx9ON137Yy6s/7iW/sOSX5V3PD8XL3cy3W47xwW+HShxzNyse6N+8SnEWMXSCqgil1IPAgwCNGzd2cTRVp5Tivr7NHNs/78nAqjXXtAlzYVQVU9as7BU5xwhLxdc3V5rBv6xZ+0X1K2+ZnMomKatVk3o6h70nzmNqN5inFibz5+ta0SjAwsfrUnh+0Q7HuUpBmJ8nZ3Py8fF0IyY6kPF9mxHk7UGAxZ0Aizt+Xm64mWxfnh8b1IqHB7bAzaRwM5twMymc+b261icorfUcYA5AfHx8naoT01oze+U+1h08xeQhbRjV1sfVIZWr+Lezsr79lfWtUtY4qnlFs/CXN6Fw0bAISVRX52qnMrvaUm1uvpV9J7Np5O9JsI876w6f46lF+8nOtwJgjr+NZduPc2tcNI0CLAxsE0qwTxeigiw0CrQQ5ueJu/n3lp8BrUMZ0Dq0zNcL9Pa4qvdXUbU+QRV36Nwhen7SExMmUGBSJmJCYnhz0JsAPLT8IVIvpOKm3PAwe+BudqdraFcmd5sMwIvrXyQrPwsvNy8sbhYsbhZaB7WmvUd7ADZmbqShaoivuy9+Hn74efjh4+6DSVVPU55Siv/e040nFmzl30t3k7g/ENw8q+W1nEkWSawdipL/1c7aL67M2Yn9slKtmyeqaTdMIc1QIc0hoBHKZKJg7YfovavBNwRTu+vQp9Pg7FH02XSSDu51XN4i1JcWob5OjdGZ6lSC8su7yMg8W7KworFSSFS+vVCVl03rtGT8KaQATR6aPMCMt+14VibbdsznKIXkosnBSr6CG4I60r77y0T4WHl2w5Nkq5KFtJGh3Xjuxv+iM/YwdvEY/DARgIlATARqM/Gd/0C32AexHt3MoaVT8M8rZH5CNg2+vhs8POC6p6FxD0hZBz88d9l78h76Aq/e0YWhlp0Eb3yeB+8KwP/LseBlT1Q3vQIhrWD39/Db65d/KKPehoAovPZ9x+fFX7fI6P+BTzBs+hg2f1Li0gZ5eXiZ7e93/Tuw/avL73+v7Rs2v77K5wnZ5L09mH/9Zw85OQUlTsvJyeFff3uczxOy4f0E+5sLgts/sj1fMQ2ObHC87ucJ2QT8MBnush///klI31rytYNbwPBXbc+/+TNk7i9x2M+/WD34ggfg3NGS10d3g0HTbM8/GwvZp0sebz4ABtgT60e3QH5uyeOtr4c+f7Y9L3pPxXW4Gbo/AHnZ8PFtlx/vcid0vQuyMmH+Hy4/3m08dLwFzqbCwj9efrz3IxDQlRYB1st/rgD9J0OLa+BYMix5qsShzxOybf/mGvdgVHwkJITyr+VHOXo2n4gAd54cHMqoXi1tJ+//qeTPrUg1/tsD4K7PwcO7Qv/22LO05DF3Lxi7AACfpDcuf/0y/u05+EfALe/Ynl/Fvz3COwG2UmrAD5MxXyg5fCQvvAsXethqDAKXTsCUe6bE8T6vH+boqazL3nIjfzcW3NeEkw37ETl4AudyCzj131sxm1LwcV+Nt4cZbw8zhVNuRMW+Avk5NPjuQfvVXiQmnbT9HJ3xb6/NDXByL3z72OXHi/7tVZGhE5RSah4wEAhRSqUCz2it3yvr/GBMPKGDLtkZ63g68dJjAI0GOp5+qEt+WyzQmoKmIzhj356dF0Suu5kLaC5g5TxWWgTbBtvmWwvww8Q5rBymgLMUct6keeDMbroBZ/OzGGE6Bl7g1iuSYHWCUNy4+/g6bmzcg6yCXJZygTDMhGGmIW74o1C2z4GETo04mWJhb8ppzKbgCn6CNS8xKZGjZy3A5RXRR8/m13xAolTR0dEltkd1acCw9r4kJiUSH9cBj0uS3aXni4oJDw8HLwvklfw8PXx88C0qnXp5grXk8afu6MuU91eVKNV6mhWju/pz7Fwep/2sxIWHEw7kRgfi6Way/7WwCwmE8HDbl6NLv7jUJlrrOvOIi4vT1eHYsWM6IiJCHzt2rFLX5RXm6Zz8HK211ll5WXrR/kX69TWv6xb3ttCPL3tcP7jsQb304FKttdY7Tu7QHT/oWOLR7aNu+vuD32uttT56/qh+6ZeXdNOEpnrp9qV6zeF9+rUfd+nCQmu1vYfKXlN0bmxsrI6IiLjsUbS/OmKtzvsYmTPfY3V9Xq7+Objq9Svyb/1SBzIu6Pd/OaBf+G6nXrBggeN3pkmbTvruv72ql29P12ey8mo0pqoAEnUV/qYbugRV27mb3HE3uQPg7e5NQvME0r3T+efSfzLln1NK1O+3CmrFkluWcCL7BMezjnM8+zjpWek08WsCwN4ze/lg3wf43ubLpA22qgGtzaz6cBLv3n4H6TkH+SXtF6J8o2js35hov2h83K+uU0V5vfGu1FOvaJHEsto0JkyYcFUx1VbSO7H+qugcm5uPnOGrTWms3H2CQ5nZADQP9WHSYzfTu3dv4uK7sXblMqe0B9a2eT8lQRmEm8mNSN9IIn0jSz3eP6o/iwYtou8NfZn9yWxy3HP4ftd2ViWZufn1Xxk18Ahvb3+5xDXBXsF8eMOHRPtHs//cftzbu3P4wmEaFDbAw1x2sX/WrFk0a9asUr3wirt05vaipDVq1Kh6l6Ckd2L9VdbvyemsPH7YdYLB7RoS4O1O4qFTzFufQu8WwdzbpxkD24TSJLjYl0ttrfaYjEoSVC3iafbEmmklPiSe8PBwbmtzG+s6ZfKnTzbx5jehvHPPdzQIuEDK+RSOnD9CyrkUQrxDAPjx2I/4jfXj/l/vx/SbiSjfKJoFNGPmwJl4mj05kX0Ci5sFPw/bZLVX0wvv0kUSe/fuTVxcHIsXL3b8Qa5t3+BE5VRkLFxVzq+t0s/msmxHOku2pbPu4CkKrZrXxnTlps4RjOnemLE9m+DlbnZ1mIZj9KmOxBX0aB7M4j/3ZVRsJHHREbQLbsf1Ta/n/k7381yf57C42RZJvKvFXZx94yxPdnqSBzo9QNsGbTmfdx5Ps6034EsbXqL3vN4M+nwQykeVOQajPLJIojDKHH8zZ84kMjKSyMhIR7fsuLg4x76amIaooNBW8kk9nU3PF37g6a+3c+L8RR4a0JxvHunDsJhGAPh4uklyKoOUoOqAhv5e/ONmW7fWszn5TPtmO0/e0JaG/l6Oc7zdvClMK+S6iOtKrV4a3WY0rRu05sCZA+zM2lnq66Snp2MZZGHpoaW0CWpDtF80ZpOxfrFKa/MpPm5E2nxqjjNnQ6is4lWrNSnj/EW+23qMb7ccJTLIwn/u6EpUkDfPj+hArxYhtAwz7pgjI5IEVcfsPHaOJdvSWb33JP3Me5n/+j9KHC/rj3V8eDzx4fEAzGVuqfd2D3LHa6AXk3+2DWy+JvoaXr3WNhZk0YFFNPZrTKugVo5Smyu46g+T+F19nONvybZ0Plp7mN/2n8SqoW24H50iAxzH7+7V1HXB1WKSoOqYns2D+eaRPjz0URJfn2zMXz/6mYcHtMBkqtwEWRaL5bJeeDOem8GExyewbOMy9pzaQwOvBgBk52fz19V/RaMxKRPN/JvRNrgtfYP6OvW9idqhPszxl19oZfXeDPq3CsXNbGLzkTOknMrmT9e05KbOEbRuKAuPOkOVEpRSygfI1VoXOike4QStGvrx9SN9eXJBMv9eupucvEImX9+mUveYMWNGmb3wOgR3oENwB8e5FjcLS25Zwq5Tu9h5aie7MnexIX0DTT2aAnAs+xj3f3k/7Ru0p0NIB9oHt6d9cPur7gYvjK2uzvGntWb70XMs3JjGN1vSOHkhj7njuzOgdSiPDWrFE0PbyAoETlapBKWUMgF3AHcB3YCLgKdSKgP4Dpijtd5bzi1EDfH1dOO1MV3p3SKE69rZZkLXFVzCY+LEiZXqhaeUIsI3ggjfCK5tfK1j/9FjR3me58m35tMysCWbMjbx/aHvbdegeP261+kf1Z+M7AzSs9Jp06BNud3fRe1QF+f4O3omh/EfbGBX+nk8zCauaxfGqNgoerewzeoinRyqR2VLUD8BK4CngG1a2zroK6UaANcA/1JKfam1/si5YdZfVWn0V0pxZw/bEiSFVs19czfQq3kwD/RrXm6VX3ltOJVp3ymaRLexb2NeueYVADJzMtmRuYPtmdtp26AtAMsOL+Nf6/+Fm8mNtkFtaeHTAo8uHuQW5pZ1a1ELlDcezugKrZpVezI4k5PHyK5RNPT3IjLQwl09GnNT54hqn8Vb2FQ2QQ3SWl82oZrW+hSwAFiglHJ3SmQCcF6j/8WCQrw9zLzw/S5+25/JzNGdCfGt+ZnRgy3B9IvqR7+ofo591ze9njDvMLae3Mq2k9tYmrYUn1t9sNoHKH67/1vSLqQRExpDp5BOjrFawnguLWGXVRIv63xXO3Iqm/mJR/g8MZX0c7m0Dffj5i6RmE2K9+7p5urw6p3KJqi1SqkbtdbHyzqhtAQmXM/bw4037ozl43UpPLdoBzf+ZzWv3N6F3i1DXB0aIZYQBjcZzOAmgwFIO5ZGz+t74n2Dbab5xOOJfLn3SzQahaJFYAt6RfRiSjdZwsNoKvtlykg9Lt9cuY9/L92NAvq3DmXa8PZc27ahtCu5UGUTVFfgOeCy+deVUn5AW631hsuuqoXq4ngapRRjezYhtnEQj8zbyJQFyfw4aSAebsYar21WZqyZv0/v8mzvZ5kcP5mtJ7eSnJHM5ozNpGf93vj+wLIH8DJ70TmsM13DutIhuANebl6l3VoIh8OZWcxbf4RbYiNp1dCPHs2CefS6VoyOjyYi0HVDJcTvKpugtgEdlFKDtdbLLzn2MWBSSp3UWt/jlOhcqC6Pp2kf4c+iCX05eiYHDzcTeQVW0s/m0jjY29WhlcnPw4/eEb3pHVFy/IzWmkjfSJKOJ7EydSVgm9fw3g738udY21pNZ3LPEOgVWMMRCyPKL7Tyw87jfLwuhdV7T2I2KZoEe9OqoR9xTYKIa1LKkjzCZSqboAqBe4BvlFL3a61/K3ashda6g1LqTqdFJ6qNt4cbLcNsbTmv/rCX//56kGduas/o+OhaVaWhlGJa72kAnM49zZaMLWw6sYl2we0ASM9KZ/AXg2kW0IzYsFi6hnUltmEsUb5Rtep9iqortGqGvLyKgyezaBTgxeODWnN7t2jCA6S0bVSVTVAvaq33KaVuA+YqpbZh69nXC9gNoLUuZWlMYWR39mhM4uFTPLFgKz/sPMELozoR7IIOFFUV5BXEwOiBDIwe6NjnbnLnsdjH2HRiE8sPL2fBXtsqq//u/2+GNhvKqdxTnMw5ScvAlo5eh6JusFo1v+w7yao9GUxNaIfZpBjXqwlRQd4MbGMbYCuMrVIJSmv9qf3/25VSPYGhQHdgP/Ck88MTNSEi0MIn9/fkvV8O8u+lu7n+lVW8NiaWZnVgHG2wJZj7Ot0HgFVb2X9mPxuPbySuoa09cdmhZUxfNx1/D39iw2KJaxhHfHg87Rq0M9w8g6JizmTn8UVSKh+tPcyhzGyCfTx4sH9zwvy9uKdPM1eHJyqhsgN1lX2VRLTWBcAi+6PUc0TtYTIpHujfnH6tQ3jii2SCfT2gjnXINCkTrYJa0SqolWPftY2vxdvdm6TjSY52LIVi9R2rCfAMYPOJzWg0HYM74m6WERRGt/7gKe5+bx0XC6zENQni8cGtGdoxHE83+bJRG1V6oK5SagHwtdY6pWinUsoD6AuMw1bl94HTIhQ1qm24P1/9qQ9KKdLTszDF3sq6w+cYUctG/ldUmHcYw1sMZ3iL4QBkZGew69QuAjxtE32+teUtfj36q62XYGhn4sLj6NmoJ13DuroybGGXm1/IouRjWNzNJMQ0olNkAGO6N2Z0fDTtI/xdHZ6oosomqKHAeGCeUqoZcAawYFtXahnwstZ6szMDFDWvqPPAhYuFmCI78uiXe1mTmstTN7YjwFK3SxGh3qGEeoc6tl/o9wIbj28k8XgiiccTmb15NuuPref9oe8D8MWeL2ji34SY0BjH2lqi+h05lc1Haw/zWeIRzmTnM6hdGAkxjbB4mJk2vMOVbyBqhcq2QeUCbwJv2meMCAFytNZnlFIBWuuz1RFkbVdbx1T5epopWPwP7p21gE8Sj/DT7hM8P6IjQzrUzdJUaYK8griuyXVc1+Q6AM5ePMvp3NMAXCy8yAvrXiDPmoeHyYPOYZ3p1rAb1za+ljYNKjc5r6i4l5bu5o2V+zApxeB2DflDryb0ss+JJ+qWq57N3D5jxDEApdQnwFmllDfwntZ6lZPiqxNq9ZgqawGP9ItidK+WTPkimcmfb2F18+A6X5IqS4BngKP6z9PsyU+3/8Sm45vYkL6BDcc38FbyW3i7e9OmQRtO557m012f0i28GzGhMS6OvPY6nZXH50lHuLlrJGF+XsQ1CWLCNS0Z06MxjQJkQG1d5qz1oHZprZ8DUEq9CTglQSmlhgL/AczAu1rrfznjvqLyYqIC+XZCX/Yev0CAxR2rVfPdtmPc2LFRiYlna2tp8Wr5e/gzIHoAA6IHAHAu75zj2I7MHczeMps3t7yJp9mTdgHt8LrGi8yLmYRTf0qhV2vLkTP8b81hvk0+Sl6BlUCLB6O7RXNN2zCuaRvm6vBEDahyglJKvQO0VUqdAZKxtUtVmVLKDLwBDAZSgQ1KqW+01juccX9Ree5mk6PhefnO4zzyySa6RB/knyM7OfZXtrQ4c+bMCp9fmXNdxd/j94b5PpF9WH3HajYe38j69PX8lvob3oO9ySmwLT/xa9qv7MjcQbfwbnQI6YC7qX6WSi+VV2Bl9Ntr2HzkDN4eZkbHRzG2ZxPahkunh/qmyiPVtNYPYEsiG4DO2NqlnKE7sE9rfUBrnQd8Coxw0r1FFQ1p35CXb+9Myqlshr22mme+3sbZ7Mp3S7+0tLVw4UISEhIA24J3CxcuLPPc2iDAM4BrGl/DE92f4O3eb3P6+dNEekcCsC59Ha9uepW7v7+bvvP68tCKh/jvtv86ZnG/1MyZMyv9+ldzjSvsO3GBj9YeBsDDzURckyCeH9GBdX+9jn/c3EmSUz3llKHUWutcrfUarfV/tNYPOuOeQCRwpNh2qn2fMAClFCO7RvHjpAGM7dmED9ce5r65VZsneOHChUyZMsWxCmt6ejpTpkwpkaRqO53z+6KRE+MmsnL0SmYOmMlNLW7i2IVjfL3va8eMFnOS5zB3+1x2Zu7Eqq2VSuZFjJzU8wqsLEo+yh1z1jBo1s88t2gHp7LyAPj7sPbc3aspfl5SqqzPnNIGpZSaBvQA0oBNWus3nHHbUvZdNgBYKfUg8CBA48aNnfCyojICvT14bkRHbu8WTW5+IQAXLhawPe0sPZpXrGdVUUKaPn16idVXAXJycpg+fTq9e/cu7dJaL9gSzJCmQxjSdAiAo/oPYOWRlWw9uRWwVR36jvVl6aGlXN/0ekcyL/q8ipI5UCsWBFx7IJNHPtnIyQt5RAZa+Mv1bRgdH00DH1kIUPzOWZ0kAoG1wP+Ax510z1Qguth2FHD00pO01nOAOQDx8fEyg4WLdIgIcDyf+9sh25RJHRry1A3taBpS/pxJxTtRlCY9Pf2K59QVFrffe6V9kvAJx7OOs+H4Bjakb+DzY5+zIWUDnb06175kbjLz497TNLngRp+WIbQM8yWuSRB3dG9M/1ahmMtZ4VnUX85KUKfs9zphf+4MG4BW9gHBacAdgMyUXgvc17cZWmveXLmfH3b+zJ09GjPh2laE+pU+kDUpKQmwVVMVlaaKCw8PZ/HixfUmSRXX0Kchw5oPY1jzYbx727vMNs1mtnV2mecbLZnvz7jA+6tTcbvlRf66+AAJnXLo0zKEEF9P3r473tXhCYOrVBuUvTrtMvYu5m8BrwJOGaxrn+vvEWApsBOYr7Xe7ox7i+rl5W7mkWtbsXLyQG7vFs3H61L465dbyzw/PDyc8PBwpk6disVSclyLxWJh6tSply0VXl8lbUgiKSmpzM8jOCyYpKQk3ln2Dje/dzOePTw5cOYArpge86mFyVw382fmbTyOPrGfWSNa8uoYmSJKVFxlO0k8VNYBrfVRrfV9WuuXqxhT8Xt+p7VurbVuobWe7qz7ipoR5u/F9JGdWDFxAE/e0BawTVHz2g97OZ97eY+/UaNGMWPGDMcf3/DwcGbMmFEr2lRqypWS+bS/TyM8PByrxcqu87vwGeHDiK9HMHD+QCb/PJnzeeerJS6tNYmHTvHXL7dy4WIBAD2bB/PkDW355v4YCn+eTe9mAVKVJyqlslV88q9LVFqzYm1QP+w8zszle3jv14M80K85f3pscolzR40aRe/evYmLi2Px4sUlSgoTJ06ssZirqrrHdxUl7enTp5Oenu5IWkX7hzUfRkKzBBrHNOaVBa+QeDyR/Wf24+vuC8CspFmknk8lvmE88eHxtAxsWanXL5J6OpuvNqWxcGMaB05m4e1hZkTnCHo0D2ZEF1un29KqbUXZ6ttg93JprSv8ADZW5vyafsTFxWnhPMeOHdMRERH62LFjTr3vliOn9b3vr9dNnlikOz69RL+8fHeNvG5NioiIKLG9YMECHRsbqyMiInRsbKxesGBBmeeW5aWXXrps35U+q9Ku0VrrV5Je0YM/H6w7ftBRd/ygo+4zr4/+6w9/ddzLarWWGUfRsZTMLN3kiUW6yROL9G1v/aY/25CiL+TmVzpGUXcBiboKf9MrW4LqrJQ6V8p+Zct1WkbTiSuKiQrkv/d0Y1vaWWav3E/G+YuOY0dOZVPXRr44q0v41XxrLuuaR2Mf5dHYR0m7kEZieiJJx5OwWG1Vhlprhn05jGj/aOIbxhPXMI6WAW35bd9Zvt6chp+nOy/eGkN0A2/+cXNHBrQOJbqBd6VjE+JKKjubuaz6VcfVZPVCx8gA3rgrFqvV1oC/MeU0o978jV5N/VGN2rmkYb9IaZ9DcRX5HGrD+K5I30giW0YyouUI0tPTeZ3XyS3MpWejniQeT+Q/af+xnWh1I/fEjQTkD+SWuAiy8rPwcfdhbM8mLo1f1G3KlX8EnC0+Pl4nJia6OgxxlTIvXOSjtSl88NsBTmcX0DjIkz/0bs6dPRrj7eGsERGVV9R1u7zec5eKjKzcpCdpaWlXE9pVxVbuvbr14LX5y7ipeyvczSaeWbSOhTtW0yTyOCNaD+He2OvYfmor474fR5sGbYgNiyW2YSxdw7oSYil9ljNnxihqF6VUktb6qscTVLgXn1JqsFLqHaVUF/u2s6Y0EgKAYF9PHh3Uiq/Hd6Lg1/8S4OXGaz/a1v0BOHomx1Haqg2SksrvEh4eHu4YA+ZK53PzWZR8lKe/P4jbbS8x8et9rDtgG8448bpYEic+zqK7/s0D3QbjZjbRwKsB93W6Dx93Hz7f8zkTV07kmvnXsPnEZgCOXTjGgTMHypxTUIiKqszX0v8D7gX+ppRqAHSplohEvefhZkIfWMs7t7+B2ScIL3czWmvGvruOiwVWRsVGcnPXSFqE+ro61HIVJaapU6eWaIMC14/vKii04mY28dcXX+Pjk9Eoszs69zw6NZnCw0nc/vEusBaUWpUZ7RfNhK4TAMgvzGfHqR1sPL7RsUjj/D3zeXfruwR4BtA5tDMtLS1xa+ZGoS6s8fcparfKJKgMrfUZYLJS6l9At+oJSYjfFc0+YdXw2ODWfJGUyhs/7eO1H/fRNtyPxwa1ZmhHY1cbXalLeE3IzS9k/cFTrN6bwcrdGfRtFcIzN3Xg+b88QuCy3QxsE0ZckyDMpjsqdV93szudQzvTObSzY9+trW+lsV9jNmdsZtOJTaxKXYXvWF+UfZTKkoNLsGorncM6E+ET4Zg8V4hLVSZBLS56orV+Uik1oRriEaJUZpNieOcIhneO4Pi5XBYnH2NR8lEK7VV+hzOzmJ94hMHtw4mJDCixiKIrXDpmq6bHd2n9+6zpj3+2me+2HuNigRUPs4luzYLoFGmbO9FsUkwZ2taprx3pG8nIViMZ2WokAHtS9jDotkGYbra1KMzdPpdtmdsACLGEEBMSQ/+o/tzS+hanxiFqvwonKK3115dsv1Z8WykVaC9hCVGtGvp7Mb5vM8b3bebYt/nIGd76+QBv/LSfEF8P+rQMoV+rUG7sFO6SDhaV6enojF6RuflW1h7IJOnwaTYcOkX62VyWPNYfgPAAL+7q0YR+rUPo0axBjX8e/h7+FKb+Xr334Y0fsvf0XrZkbGFLxha2ntyKl5sXt7S+Ba01Dyx7gCi/KDqFdKJjSEdaBLbAzeS6TjLCdcr9qSul2gN/1VqPLbbPB+hgf3S0/78T4A0EVV+oQpRtRJdIBrQO5cddJ1i1J4Nf9p1kUfIxhnRoCMDyHcc5nZ1Ht6YNaBrsXaurlQoKrezPyKJFqG2GDlOH6xk0ezMF9tJkqzBfujdrwMWCQjzdzDzh5BJSVbmZ3GgX3I52we24o62tSrHAapseKacgBzeTG8sPL2fB3gWAbYb3R2Mf5a52d5FvzSf9QjpRflG1+mcoKuZKX0t+AHoVbSilDgHuwA5gF7ZJXMcAXbTWJ6opRiEqJNDbg1GxUYyKjcJq1Rw+lY2/fcG7+YlHWL7jOAD+Xm50igqgV/NgHrm2FQBWq3Z5tWBZjpzKZtmO4+xOP8fOY+fZffw8eQVWvn+0H0EK9KkU7oxtyIAOUcQ1CSLQu/atqVRUQvJ29+atwW+htSblfArJGclsz9xOswBbaXnP6T3csegO/Dz86BDcgfbB7Wkf3J4e4T0I9Ap04TsQ1eFKCWoIMB24y769CBgAvKO1ng+glPqLJCdhNCaTKjEH4Ntj49iXcYGNh0+TnHaW5NQzrD902nF8+Bu/kJtvpWmwD02CvWka7E2HyABiG1d/pcC53HzW7M/k+LlcjpzK5nBmNimnsnnqxnYMaB3K/owLPL9oBw18PGjfyJ9xvZrQrpE/4f5eXDyfjT62k//rG0l4eMNqj7WmKKVo4t+EJv5NuKnFTY794d7hPNPrGbZnbmf7ye38b8f/KLAW8M6Qd+jZqCebT2xmxeEVthJag3Y08W+C2STzC9RW5SYorfVWfk9OaK0fUUo1BZ5VSk0B/k4pq9wKYTQmk6J1Qz9aN/SjqJ9a8UHqg9o1ZPvRc6RkZvPLvgxy863c3CXCkaDcbpvFsHeSaeC7m0BvD/y93BnSviGju0WTX2hlxpJdmJTCZLL1VSuwanq3CGZgmzDOZOfx1MKtnDqXjfn6Jxg9dxtnc5OZOLg143o3Jf1sLn/80DYeytPNROMG3jRu4I2H2dapoGfzYBL/NohgH4/LqrXSq2dycsMKtgRza+tbuZVbAcgrzGPv6b2OEtbeM3uZt2seeVbb0vFeZi9aB7XmP9f+hxBLCJk5mXi5eeHjXv4imsIYKt3yqLU+BIxTSnUA/gGEK6UGaq1XOjk2IapV8T/2jw1q7XiutebE+YuOHoKFVo1132p6x9/NRW3mTHY+qaezOZllm0OwoFDz8boUCq0arcGqNe5mE76ebgxsE4ZSir0nLuChrFCYR6sQbyJD/GnV0DaOq0mwN98+0peGAZ6E+HheVtXo5W7Gy11KAaXxMHvQIaSDY/u21rdxc8ubOXDmALtP72bXqV3sO72PQM9AAGZvmc1nuz8jyjeK1kGtaRXUijYN2jCo8SBp0zKgq+4ao22LB45USvUApiulntNa93deaEK4hlKKhv5ejm2zSWHd9CV/ffdvpQ6stXiY2fHc0DLvF2BxZ8XEAbYpf14ay/QXx5a4j6ebmU5RAc59E/WYu8mdNg3a0KZBG4a3GF7iWELzBEItoew5vYe9Z/ayMnUl4d7hDG4yGIAZG2aQmZNJy8CWNA9sTsvAlkT5Rkk1oYtUue+m1nodMEgpNcgJ8QghRLXpGtaVrmG/r+qbW5BLRnaGYzs7P5uNJzby3cHvHPviG8bz/tD3Afh016f4e/jTNKApTf2b4u0us7hXJ6cNLtBar3DWvYQQoiZ4uXkR7R/t2J7WexoAWflZHDhzgH1n9jnaq6zaystJL5NdkO04P8w7jNGtR/PHzn9Ea82q1FVE+kYS5ReFl5sXompk9JsQQlzCx92HTqGd6BTaybHPpEysumMVKedSOHTuEAfPHuTwucOEeocCcPbiWR758RHH+WHeYUT7RXNn2zsZ0nQIFwsvsv3kdiJ9Iwn1DsWkKjxXd70lCUoI4XR1ddlyT7MnrYJa0Sqo1WXHfDx8mJcwj5RzKaScT+HI+SOknk91DEI+ePYg45aMA2ztZOE+4UT4RPBgzIN0b9Sd07mn2Z65nXDvcBr6NMTX3bfed9yQBCWEcLpJkybVygRUFe4mdzqGdKRjSMdSj0f5RjF70GyOXjhK6oVU0i+kczTrqOP4lowtTPjx9ylOLW4WGno3ZHrf6cSExrD39F5+TfuVYEswIZYQgi3BBHsFE+QVVGdLY5KghBCiBvh6+NI3sm+Zx+MaxjF36FzSs9I5kX2C49nHOZF9ggBPWw/PzRmbmZk087LrFg5fSKugViw+sJj5u+cT6BlIoFcgAZ4BBHgEcEfbO/Bx9+HohaOczj2Nr4cvfh5++Lr74mE29qwjkqCEEMIA/Dz8iG0YW+bxW1vdyvVNryczJ9P2yLX9v5FPI8DWRmZSJlLOp7D15FbOXDxDvjWfW1vbBjXP3z2f97a9V+KebiY31t65Fk+zJ+9ufZcfU37E4mbBy80LT7Mnvu6+PNfnOQCWHFrCvtP78DB74GZyw0254efh55i1fs3RNZzIPoFSyrG0SlUZNkEppW4DpgHtgO5aa1nLXQhRbyml8Pfwx9/D3zFzRnE3NLuBG5rd4NjWWpNbmIuX2dabcGSrkXQJ68L5vPOczztPVn4W2QXZeJhspSgfdx/8PfzJLsjmfPZ5cgtzMavfx3/9fORnFh1YVOI1QywhjgT18c6P+Tn1Z6e+Z8MmKGAbMAp429WBCCFEbaOUwuJmcWwXzW1YljFtxzCm7Zgyj7/Q7wX+2fefFFgLyLfmU6ALsFqtjuPP9n7W1gVfg7b/1/SeplV6D4ZNUFrrnUC978UihBBGoZTC3eyOu9n9smPBlmCCCXbq69X6rh9KqQeVUolKqcSMjIwrXyCEEKJWcGkJSim1Arh8cjOYeukKvmXRWs8B5gDEx8fLzOpCCFFHuDRBaa1l/j4B1N2BnUKIq2fYNihRv9THgZ1CiPIZtg1KKTVSKZWKbcn5xUqppa6OSQghRM0xbAlKa/0l8KWr4xBCCOEahi1BCSGEqN8kQQkhhDAkSVBCCCEMSRKUEEIIQ5IEJYQQwpAkQQkhhDAkSVBCVKOZM2cSGRlJZGSkY2aMuLg4x76ZMy9fgE4IYSMJSohLVCZpXOncSZMmkZaWVuZDZs8QomySoIS4RPE5ARcuXEhCQgIACQkJLFy4sMxzhRDOZdiZJIRwtYULFzJlyhRycnIASE9PZ8qUKQCMGjXKlaEJUS9ICUqIUqSnpzN9+nRHciqSk5PD9OnTSU9PJz093UXRCVE/SAlKiFIUX+rjUunp6eUeF0I4h5SghChFUlIS4eGlraUJ4eHhJCUlkZSUVMNRCVG/SIISohTh4eFMnToVi8VSYr/FYmHq1KmEh4eXmcCEEM4hCUqIMowaNYoZM2Y4ElF4eDgzZsxweQcJGVsl6gtpgxLiEhMnTnQ8HzVqFL179yYuLo7FixdfVmoqfm5NkdWHRX0hJSghLlGZP/6SKISoPpKghBBCGJIkKCGEEIYkCUoIIYQhSScJIYTL5efnk5qaSm5urqtDEVfBy8uLqKgo3N3dnXpfSVBCCJdLTU3Fz8+Ppk2bopRydTiiErTWZGZmkpqaSrNmzZx6b8NW8Sml/q2U2qWUSlZKfamUCnR1TEKI6pGbm0twcLAkp1pIKUVwcHC1lH4Nm6CA5UBHrXUMsAd4ysXxCCGqkSSn2qu6fnaGTVBa62Va6wL75logypXxCCGEqFmGTVCXGA987+oghBB1l6+vb4ntDz74gEceeaTca4qfM23aNF566SUAnn76aVasWFE9gQKHDh3CYrHQtWtX2rVrR/fu3Zk7d261vZ6ruLSThFJqBVDajJtTtdZf28+ZChQAH5dxjweBBwEaN25cTZEKIUTFPffcc9X+Gi1atGDTpk0AHDhwgFGjRmG1Wrn33nur/bVriksTlNZ6UHnHlVLjgGHAdVprXcY95gBzAOLj40s9RwhRu9z+9prL9g2LacTdvZqSk1fIPe+vv+z4rXFR3BYfzamsPB7+qORSKJ/9sVeV4snIyOChhx4iJSUFgFdeeYU+ffqUef4999zDsGHDuPXWW2natCnjxo3j22+/JT8/n88//5y2bduSkZHBnXfeSWZmJt26dWPJkiUkJSVhsVgYPXo0qampFBYW8ve//53bb7+93PiaN2/OrFmzmDRpEvfeey+nTp1i/PjxHDhwAG9vb+bMmUNMTAydOnVi9erVBAQEEBISwssvv8wf/vAH7r77bsaNG0dqairffPMN2dnZ7N+/n5EjRzJjxgwKCwu57777SExMRCnF+PHjefzxx6v0mVaEYav4lFJDgSeA4VrrbFfHI4So23JycujSpYvj8fTTTzuOPfroozz++ONs2LCBBQsWcP/991fq3iEhIWzcuJGHH37YUQ347LPPcu2117Jx40ZGjhzpSH5LliwhIiKCLVu2sG3bNoYOHVqh14iNjWXXrl0APPPMM3Tt2pXk5GT++c9/8oc//AGAPn368Ouvv7J9+3aaN2/O6tWrAVi7di09e/YEYPPmzXz22Wds3bqVzz77jCNHjrB582bS0tLYtm0bW7durbFSmpHHQb0OeALL7T1E1mqtH3JtSEKImlBeicfiYS73eAMfj6sqMVksFjZv3uzY/uCDD0hMTARgxYoV7Nixw3Hs3LlznD9/vsL3LlqiJS4ujoULFwLwyy+/8OWXXwIwdOhQgoKCAOjUqROTJ0/miSeeYNiwYfTr169Cr1G8kumXX35hwYIFAFx77bVkZmZy9uxZ+vXrx6pVq2jSpAkPP/wwc+bMIS0tjQYNGjja4K677joCAgIAaN++PYcPH6ZDhw4cOHCACRMmkJCQwJAhQyr83qvCsCUorXVLrXW01rqL/SHJSQjhElarlTVr1rB582ZHacLPz6/C13t6egJgNpspKLB1Ti6j1YLWrVuTlJREp06deOqpp3juuedYt26do2T3zTfflHrdpk2baNeuXZn3VkrRv39/Vq9ezerVqxk4cCChoaF88cUXJZJgUazF4w0KCmLLli0MHDiQN954o9IlyKtl2AQlhBBGMWTIEF5//XXHdvGS1tXq27cv8+fPB2DZsmWcPn0agKNHj+Lt7c3YsWOZPHkyGzdupEePHo7kOHz48MvudejQISZPnsyECRMA6N+/Px9/bOtXtnLlSkJCQvD39yc6OpqTJ0+yd+9emjdvTt++fXnppZeuWEo7efIkVquVW265heeff56NGzdW+f1XhJGr+IQQwhBeffVV/vSnPxETE0NBQQH9+/fnrbfeqtI9n3nmGcaMGcNnn33GgAEDaNSoEX5+fqxcuZK//OUvmEwm3N3dmT17dqnX79+/n65du5Kbm4ufnx8TJkxwtA1NmzaNe++9l5iYGLy9vUt0Qe/RoweFhYUA9OvXj6eeeoq+ffuWG2taWhr33nsvVqsVgBdeeKFK772iVFnFzNooPj5eF9UZC+Es6enpxMXFkZSUdNmKusI5du7c6aieqi8uXryI2WzGzc2NNWvW8PDDDzulZOYqpf0MlVJJWuv4q72nlKCEEMIFUlJSGD16NFarFQ8PD9555x1Xh2Q4kqCEEMIFWrVq5RhoK0onnSSEEEIYkiQoIYQQhiQJSgghhCFJghJCCGFIkqCEEALbTAt33323Y7ugoIDQ0FCGDRvmwqhsBg4cSH0cQiMJSgghAB8fH7Zt20ZOTg4Ay5cvJzIy0sVR1W+SoIQQxvN+wuWP9fZxQnnZpR/fZF8yLivz8mMVdMMNN7B48WIA5s2bx5gxYxzHTp06xc0330xMTAw9e/YkOTkZsM3aMH78eAYOHEjz5s159dVXHdfMmjWLjh070rFjR1555RXANi1R27ZtGTduHDExMdx6661kZ9sWbPjhhx/o2rUrnTp1Yvz48Vy8ePGyGJctW0avXr2IjY3ltttu48KFCxV+f7WNJCghhLC74447+PTTT8nNzSU5OZkePXo4jpW1hAXArl27WLp0KevXr+fZZ58lPz+fpKQk3n//fdatW8fatWt55513HOOedu/ezYMPPkhycjL+/v68+eab5Obmcs899ziWuigoKLhsmqOTJ0/yj3/8gxUrVrBx40bi4+OZNWtWzXw4LiADdYUQxnPv4rKPeXiXf9wnuPzj5YiJieHQoUPMmzePG2+8scSxspawAEhISMDT0xNPT0/CwsI4fvw4v/zyCyNHjsTHxwewLbmxevVqhg8fTnR0tGPBw7Fjx/Lqq68yePBgmjVrRuvWrQEYN24cb7zxBo899pgjhrVr17Jjxw7HtXl5efTqVbXFGI1MEpQQQhQzfPhwJk+ezMqVK8nMzHTsL2sJCyh9iYry5jktuq74dkXmRdVaM3jwYObNm3fFc+sCqeITQohixo8fz9NPP02nTp1K7C9rCYuy9O/fn6+++ors7GyysrL48ssvHctapKSksGaNbVn7efPm0bdvX9q2bcuhQ4fYt28fAB9++CEDBgwocc+ePXvy66+/Os7Jzs5mz549znnjBiQJSgghiomKiuLRRx+9bP+0adNITEwkJiaGJ598ssQSFqWJjY3lnnvuoXv37vTo0YP777+frl27AtCuXTvmzp1LTEwMp06d4uGHH8bLy4v333+f2267jU6dOmEymXjooZLrtIaGhvLBBx8wZswYR2eNomXe6yJZbkOIK5DlNqpffVpu49ChQwwbNoxt27a5OhSnqo7lNqQEJYQQwpAkQQkhRA1q2rRpnSs9VRdJUEKUYubMmURGRhIZGUlcXBwAcXFxjn0zZ850cYRC1H3SzVyIUkyaNIlJkya5Ogwh6jUpQQkhhDAkwyYopdTzSqlkpdRmpdQypVSEq2MSQghRcwyboIB/a61jtNZdgEXA0y6ORwhRh5nNZrp06UKHDh3o3Lkzs2bNwmq1ApCYmMif//znq7rvoUOH6NixozNDrTcM2waltT5XbNMHqDsDtoQQhmOxWNi8eTMAJ06c4M477+Ts2bM8++yzxMfHEx9/1cN5xFUybIICUEpNB/4AnAWuKeOcB4EHARo3blxzwQkhqs29S+69bN/1Ta/njrZ3kFOQw/+t+L/Ljo9oOYKbW97M6dzTTFw5scSx94e+X6nXDwsLY86cOXTr1o1p06bx888/89JLL7Fo0SKmTZvG/v37SUtL48iRI0yZMoUHHngArTVTpkzh+++/RynF3/72N26//fYS9y0sLOTJJ59k5cqVXLx4kT/96U/88Y9/rFRs9YlLE5RSagVQ2tD8qVrrr7XWU4GpSqmngEeAZy49UWs9B5gDtpkkqjNeIUT90bx5c6xWKydOnLjsWHJyMmvXriUrK4uuXbuSkJDAmjVr2Lx5M1u2bOHkyZN069aN/v37l7juvffeIyAggA0bNnDx4kX69OnDkCFDaNasWU29rVrFpQlKaz2ogqd+AiymlAQlhKh7yivxWNws5R4P8gqqdImpLGVNBTdixAgsFgsWi4VrrrmG9evX88svvzBmzBjMZjMNGzZkwIABbNiwgZiYGMd1y5YtIzk5mS+++AKAs2fPsnfvXklQZTBsFZ9SqpXWeq99czhQd2dEFEIYzoEDBzCbzYSFhbFz584Sx6qyXMZrr73G9ddf79RY6yoj9+L7l1Jqm1IqGRgCXD69sBBCVIOMjAweeughHnnkkcuSEcDXX39Nbm4umZmZrFy50lGd99lnn1FYWEhGRgarVq2ie/fuJa67/vrrmT17Nvn5+QDs2bOHrKysGnlPtZFhS1Ba61tcHYMQov7IycmhS5cu5Ofn4+bmxt13383EiRNLPbd79+4kJCSQkpLC3//+dyIiIhg5ciRr1qyhc+fOKKWYMWMG4eHhHDp0yHHd/fffz6FDh4iNjUVrTWhoKF999VXNvMFaSJbbEEK4XG1abmPatGn4+voyefJkV4diKLLchhBCiHrDsFV8QghhRNOmTXN1CPWGlKCEEIZQl5ob6pvq+tlJghJCuJyXlxeZmZmSpGohrTWZmZl4eXk5/d5SxSeEcLmoqChSU1PJyMhwdSjiKnh5eREVFeX0+0qCEkK4nLu7u8ymIC4jVXxCCCEMSRKUEEIIQ5IEJYQQwpDq1EwSSqnzwG5Xx1GOEOCkq4Mog5FjA4mvKowcG0h8VWHk2ADaaK39rvbiutZJYndVptWobkqpRKPGZ+TYQOKrCiPHBhJfVRg5NrDFV5XrpYpPCCGEIUmCEkIIYUh1LUHNcXUAV2Dk+IwcG0h8VWHk2EDiqwojxwZVjK9OdZIQQghRd9S1EpQQQog6QhKUEEIIQ6ozCUopNVQptVsptU8p9aSLY4lWSv2klNqplNqulHrUvr+BUmq5Umqv/f9BLo7TrJTapJRaZLT4lFKBSqkvlFK77J9jL6PEp5R63P5z3aaUmqeU8nJlbEqp/yqlTiilthXbV2Y8Sqmn7L8nu5VS17sovn/bf7bJSqkvlVKBroivtNiKHZuslNJKqRBXxFZefEqpCfYYtiulZhgpPqVUF6XUWqXUZqVUolKq+1XHp7Wu9Q/ADOwHmgMewBagvQvjaQTE2p/7AXuA9sAM4En7/ieBF138uU0EPgEW2bcNEx8wF7jf/twDCDRCfEAkcBCw2LfnA/e4MjagPxALbCu2r9R47P8OtwCeQDP7743ZBfENAdzsz190VXylxWbfHw0sBQ4DIQb77K4BVgCe9u0wg8W3DLjB/vxGYOXVxldXSlDdgX1a6wNa6zzgU2CEq4LRWh/TWm+0Pz8P7MT2h20Etj+82P9/s0sCBJRSUUAC8G6x3YaITynlj+0f/nsAWus8rfUZo8SHbYC7RSnlBngDR3FhbFrrVcCpS3aXFc8I4FOt9UWt9UFgH7bfnxqNT2u9TGtdYN9cCxSt1VCj8ZXx2QG8DEwBivciM8RnBzwM/EtrfdF+zgmDxacBf/vzAGy/H1cVX11JUJHAkWLbqfZ9LqeUagp0BdYBDbXWx8CWxIAwF4b2CrZfQGuxfUaJrzmQAbxvr4J8VynlY4T4tNZpwEtACnAMOKu1XmaE2C5RVjxG/F0ZD3xvf+7y+JRSw4E0rfWWSw65PDa71kA/pdQ6pdTPSqlu9v1Gie8x4N9KqSPYfleesu+vdHx1JUGpUva5vP+8UsoXWAA8prU+5+p4iiilhgEntNZJro6lDG7Yqg1ma627AlnYqqlczt6WMwJbFUUE4KOUGuvaqCrFUL8rSqmpQAHwcdGuUk6rsfiUUt7AVODp0g6Xss8Vn50bEAT0BP4CzFdKKYwT38PA41rraOBx7DUhXEV8dSVBpWKrMy4Sxe/FSpdQSrljS04fa60X2ncfV0o1sh9vBJwo6/pq1gcYrpQ6hK069Fql1EcGii8VSNVar7Nvf4EtYRkhvkHAQa11htY6H1gI9DZIbMWVFY9hfleUUuOAYcBd2t5Igevja4Hty8cW++9HFLBRKRVugNiKpAILtc16bLUgIQaKbxy23wuAz/m9Gq/S8dWVBLUBaKWUaqaU8gDuAL5xVTD2bzPvATu11rOKHfoG2w8P+/+/runYALTWT2mto7TWTbF9Vj9qrccaKL504IhSqo1913XADowRXwrQUynlbf85X4etjdEIsRVXVjzfAHcopTyVUs2AVsD6mg5OKTUUeAIYrrXOLnbIpfFprbdqrcO01k3tvx+p2Do8pbs6tmK+Aq4FUEq1xtaJ6KSB4jsKDLA/vxbYa39e+fiqs4dHTT6w9RbZg61nyFQXx9IXW9E1Gdhsf9wIBAM/2H9gPwANDPC5DeT3XnyGiQ/oAiTaP8OvsFVpGCI+4FlgF7AN+BBbrySXxQbMw9Yelo/tD+p95cWDrQprP7alaW5wUXz7sLVHFP1+vOWK+EqL7ZLjh7D34jPQZ+cBfGT/97cRuNZg8fUFkrD12FsHxF1tfDLVkRBCCEOqK1V8Qggh6hhJUEIIIQxJEpQQQghDkgQlhBDCkCRBCSGEMCRJUEIIIQxJEpQQQghDkgQlhJMppcbY18LZal9PaNMlxy32ST7NpVw7TSk1+Spf10Mptco+y7oQtZ4kKCGcTGs9D7gNOI9tyquES04Zj20utUInv24etlkjbnfmfYVwFUlQQjiZUqoDtnnHntNa36+1vnRCzLsoNlefUmqqfYXRFUCbYvvHKqXW20tjbxcvcSml/m5fkXa5sq3qW1Tq+sp+fyFqPUlQQjiRfRb7/wEPaq2XlHLcA2iutT5k347DNmFvV2AU0M2+vx22klAfrXUXoBB74lFKxQO3FLsmvthLbCu6hxC1ndRVC+FcQ4HtWuvVZRwPAc4U2+4HfKntM3orpYpm4b8OiAM22CZNx8LvS2b0Bb7WWufYr/m26GZa60KlVJ5Syk/bVnMWotaSBCWEc3UHfirneA7gdcm+0mZsVsBcrfVTZRwrjyeQe4VzhDA8qeITwrnOA73KOqi1Pg2YlVJFSWoVMNLes88PuMm+/wfgVqVUGIBSqoFSqon92C/ATUopL/uqzY5OGEqpYKBoMUUhajVJUEI41ztAqFJqp1JqkVIqoJRzlmGrpkNrvRH4DNuaSAuA1fb9O4C/AcuUUsnAcqCR/dgGbJ0wtmBbuTQROGu/9zXAd9XyzoSoYbIelBDVRCm1GFtPvnWX7O8KTNRa312Fe/tqrS8opbyxlcIe1FpvVEotBJ7SWu+uUvBCGIC0QQlRDZRSdwGZwIZLj2mtNymlflJKmaswFmqOUqo9tvasufbk5AF8JclJ1BVSghJCCGFI0gYlhBDCkCRBCSGEMCRJUEIIIQxJEpQQQghDkgQlhBDCkCRBCSGEMCRJUEIIIQzp/wFP6fKHWT11/wAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# reproduce the bottom panel of Figure 5 in https://arxiv.org/abs/2009.04496\n",
     "\n",
     "(_, caps, _) = plt.errorbar(xi_mean*180/np.pi, rho_avg, xerr=xi_err*180/np.pi, yerr=sig_avg, marker='o', ls='', \n",
     "                            color='0.1', fmt='o', capsize=4, elinewidth=1.2)\n",
@@ -232,9 +837,11 @@
     "HD = get_HD_curve(zeta+1)\n",
     "\n",
     "plt.plot(zeta, OS*HD, ls='--', label='Hellings-Downs', color='C0', lw=1.5)\n",
+    "plt.plot(zeta, zeta*0.0+OS_mono, ls='--', label='Monopole', color='C1', lw=1.5)\n",
+    "plt.plot(zeta, OS_dip*np.cos(zeta*np.pi/180), ls='--', label='Dipole', color='C2', lw=1.5)\n",
     "\n",
     "plt.xlim(0, 180);\n",
-    "#plt.ylim(-4e-30, 5e-30);\n",
+    "plt.ylim(-3.5e-30, 3.5e-30);\n",
     "plt.ylabel(r'$\\hat{A}^2 \\Gamma_{ab}(\\zeta)$')\n",
     "plt.xlabel(r'$\\zeta$ (deg)');\n",
     "\n",
@@ -248,34 +855,101 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Noise marginalized optimal statistics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "To compute the noise-marginalized optimal statistic (Vigeland et al. 2018), you will need the chain from a Bayesian search for a common red process without spatial correlations (model 2A)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(822300, 96)\n",
+      "['B1855+09_red_noise_gamma', 'B1855+09_red_noise_log10_A', 'B1937+21_red_noise_gamma', 'B1937+21_red_noise_log10_A', 'B1953+29_red_noise_gamma', 'B1953+29_red_noise_log10_A', 'J0023+0923_red_noise_gamma', 'J0023+0923_red_noise_log10_A', 'J0030+0451_red_noise_gamma', 'J0030+0451_red_noise_log10_A', 'J0340+4130_red_noise_gamma', 'J0340+4130_red_noise_log10_A', 'J0613-0200_red_noise_gamma', 'J0613-0200_red_noise_log10_A', 'J0636+5128_red_noise_gamma', 'J0636+5128_red_noise_log10_A', 'J0645+5158_red_noise_gamma', 'J0645+5158_red_noise_log10_A', 'J0740+6620_red_noise_gamma', 'J0740+6620_red_noise_log10_A', 'J0931-1902_red_noise_gamma', 'J0931-1902_red_noise_log10_A', 'J1012+5307_red_noise_gamma', 'J1012+5307_red_noise_log10_A', 'J1024-0719_red_noise_gamma', 'J1024-0719_red_noise_log10_A', 'J1125+7819_red_noise_gamma', 'J1125+7819_red_noise_log10_A', 'J1453+1902_red_noise_gamma', 'J1453+1902_red_noise_log10_A', 'J1455-3330_red_noise_gamma', 'J1455-3330_red_noise_log10_A', 'J1600-3053_red_noise_gamma', 'J1600-3053_red_noise_log10_A', 'J1614-2230_red_noise_gamma', 'J1614-2230_red_noise_log10_A', 'J1640+2224_red_noise_gamma', 'J1640+2224_red_noise_log10_A', 'J1643-1224_red_noise_gamma', 'J1643-1224_red_noise_log10_A', 'J1713+0747_red_noise_gamma', 'J1713+0747_red_noise_log10_A', 'J1738+0333_red_noise_gamma', 'J1738+0333_red_noise_log10_A', 'J1741+1351_red_noise_gamma', 'J1741+1351_red_noise_log10_A', 'J1744-1134_red_noise_gamma', 'J1744-1134_red_noise_log10_A', 'J1747-4036_red_noise_gamma', 'J1747-4036_red_noise_log10_A', 'J1832-0836_red_noise_gamma', 'J1832-0836_red_noise_log10_A', 'J1853+1303_red_noise_gamma', 'J1853+1303_red_noise_log10_A', 'J1903+0327_red_noise_gamma', 'J1903+0327_red_noise_log10_A', 'J1909-3744_red_noise_gamma', 'J1909-3744_red_noise_log10_A', 'J1910+1256_red_noise_gamma', 'J1910+1256_red_noise_log10_A', 'J1911+1347_red_noise_gamma', 'J1911+1347_red_noise_log10_A', 'J1918-0642_red_noise_gamma', 'J1918-0642_red_noise_log10_A', 'J1923+2515_red_noise_gamma', 'J1923+2515_red_noise_log10_A', 'J1944+0907_red_noise_gamma', 'J1944+0907_red_noise_log10_A', 'J2010-1323_red_noise_gamma', 'J2010-1323_red_noise_log10_A', 'J2017+0603_red_noise_gamma', 'J2017+0603_red_noise_log10_A', 'J2033+1734_red_noise_gamma', 'J2033+1734_red_noise_log10_A', 'J2043+1711_red_noise_gamma', 'J2043+1711_red_noise_log10_A', 'J2145-0750_red_noise_gamma', 'J2145-0750_red_noise_log10_A', 'J2214+3000_red_noise_gamma', 'J2214+3000_red_noise_log10_A', 'J2229+2643_red_noise_gamma', 'J2229+2643_red_noise_log10_A', 'J2234+0611_red_noise_gamma', 'J2234+0611_red_noise_log10_A', 'J2234+0944_red_noise_gamma', 'J2234+0944_red_noise_log10_A', 'J2302+4442_red_noise_gamma', 'J2302+4442_red_noise_log10_A', 'J2317+1439_red_noise_gamma', 'J2317+1439_red_noise_log10_A', 'gw_gamma', 'gw_log10_A']\n",
+      "CPU times: user 950 ms, sys: 56 ms, total: 1.01 s\n",
+      "Wall time: 1 s\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
+    "# (Note: It may take a few minutes to run this cell)\n",
     "# Change chaindir to point to where you have the chain from your Bayesian search\n",
-    "chaindir = 'chains/model_2a/'\n",
-    "params = list(np.loadtxt(chaindir + '/params.txt', dtype='str'))\n",
-    "chain = np.loadtxt(chaindir + '/chain_1.txt')"
+    "#chaindir = 'chains/model_2a/'\n",
+    "chaindir = '/home/beno/Dropbox/Szakma/Research/NANOGrav/NEMO_12p5yr/12p5yrPsrs/DE438/BE_False_setIII/12p5yrdata_2a_cRN5freqs_gammaVary/'\n",
+    "####params = list(np.loadtxt(chaindir + '/pars.txt', dtype='str'))\n",
+    "####chain = np.loadtxt(chaindir + '/chain_1')\n",
+    "#chain = np.loadtxt(chaindir + '/chain_1_thin100')\n",
+    "\n",
+    "#or using hdf5 files\n",
+    "with h5py.File(chaindir + '/chain_1_compressed_9.hdf5', 'r') as fff:\n",
+    "    chain = fff['samples'][:,:]\n",
+    "    params = [S.decode('utf-8') for S in list(fff['params'][:])]\n",
+    "    print(chain[:,:].shape)\n",
+    "    print(params[:])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
+    "param_dict = {}\n",
+    "for p in params:\n",
+    "    param_dict.update({p: np.median(chain[:, params.index(p)])})\n",
+    "\n",
+    "with open('../data/12p5yr_median.json', 'w') as f:\n",
+    "    json.dump(param_dict, f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Status:  0 / 1000  --  0.0  %\n",
+      "Status:  100 / 1000  --  10.0  %\n",
+      "Status:  200 / 1000  --  20.0  %\n",
+      "Status:  300 / 1000  --  30.0  %\n",
+      "Status:  400 / 1000  --  40.0  %\n",
+      "Status:  500 / 1000  --  50.0  %\n",
+      "Status:  600 / 1000  --  60.0  %\n",
+      "Status:  700 / 1000  --  70.0  %\n",
+      "Status:  800 / 1000  --  80.0  %\n",
+      "Status:  900 / 1000  --  90.0  %\n",
+      "CPU times: user 22min 48s, sys: 14.4 s, total: 23min 3s\n",
+      "Wall time: 5min 46s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# (Note: It may take a few minutes to run this cell)\n",
     "N = 1000   # number of times to compute the optimal statistic\n",
     "burn = int(0.25*chain.shape[0])   # estimate of when the chain has burned in\n",
     "\n",
     "noisemarg_OS, noisemarg_OS_err = np.zeros(N), np.zeros(N)\n",
+    "noisemarg_OS_dip, noisemarg_OS_dip_err = np.zeros(N), np.zeros(N)\n",
+    "noisemarg_OS_mono, noisemarg_OS_mono_err = np.zeros(N), np.zeros(N)\n",
     "\n",
     "for i in range(N):\n",
-    "    \n",
+    "    if i%100==0:\n",
+    "        print(\"Status: \", i, \"/\", N, \" -- \", i/N*100, \" %\")\n",
     "    # choose a set of noise values from the chain\n",
     "    # make sure that you pull values from after the chain has burned in\n",
     "    idx = np.random.randint(burn, chain.shape[0])\n",
@@ -286,19 +960,116 @@
     "        param_dict.update({p: chain[idx, params.index(p)]})\n",
     "    \n",
     "    # compute the optimal statistic at this set of noise values and save in an array\n",
-    "    _, _, _, noisemarg_OS[i], noisemarg_OS_err[i] = os.compute_os(params=param_dict)"
+    "    _, _, _, noisemarg_OS[i], noisemarg_OS_err[i] = os.compute_os(params=param_dict)\n",
+    "    _, _, _, noisemarg_OS_dip[i], noisemarg_OS_dip_err[i] = os_dip.compute_os(params=param_dict)\n",
+    "    _, _, _, noisemarg_OS_mono[i], noisemarg_OS_mono_err[i] = os_mono.compute_os(params=param_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Figure 4"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0.5, 0, 'S/N')"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAEGCAYAAAB1iW6ZAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/d3fzzAAAACXBIWXMAAAsTAAALEwEAmpwYAAA0Q0lEQVR4nO3deXwUVbbA8d8lAmEXBGSXRRaRXTYfCIiIUVQEN3DAgMMgjDCiA4M4IyLPYXAZdxEBBVxBEcGFAQefUVGQsIQdZDFAQHZFZCfc90d1h6RTnXTXra7udM738+lPp+tW3RwKOKncuveU0lojhBCi4CsS7QCEEEK4QxK6EELECUnoQggRJyShCyFEnJCELoQQceKiaH3jihUr6tq1a0fr24tsdhw8DkDdSqVytaX/lg5A7bK1PYwohhzaar1XrB/dOITwWbly5SGtdSW7tqgl9Nq1a7NixYpofXuRzd2vLwVg9v1X52obuHAgANOTpnsaU7j2Hd8HQJVSVRz3sffXkwBUu7jEhY3Te1jvAz931unRDOu9XA3HcQmRnVJqZ7C2qCV0Idw05tsxgNkPnodmpwH2P9gcm3u/9e70B4IQYZCELhjeNfhwwuBmgz2MxDk34rQ9D51GmnVqerwQYVDRWinaunVrLUMuQggRHqXUSq11a7s2uUIXbNh7FIArq5XL1bb5yGYAGlVo5GlM4dp9bDcANcvUdNzHrsMnAKh1SckLG39ea71Xbeas0yM/We8V6jiOy6mzZ8+SkZHBqVOnPP/ewlxiYiI1atSgaNGiIR8jCV0w/tONgP3Y8VPLnwJi/6bo2O/GAmZxjpqzBgg4DwutsXnHY+Dzh5kdbyAjI4MyZcpQu3ZtlFKef3/hnNaaw4cPk5GRQZ06oV8MSEIXceHPLf5s3MdD1zdwIZIA145xv88QnTp1SpJ5AaWU4pJLLuHgwYNhHScJXcSFNlXaGPfRvu4lLkQSoHZH9/sMgyTzgsvJ350kdBEXfjpqjVXXKed8rHr7wd8BqFeptCsxATGzMKn2I5EZ8kmf2CMi/QpnJKHHkHD+00X6P5I/lhK1Duf4HI1YQjF+6XjAbAz90bnrAJfnoX86wnovpPPQS5cuze+//571ecaMGaxYsYJXXnkl6DHZ9xk3bhylS5dm5MiRjB07lk6dOtGtW7eIxJqens4VV1xBo0aNOHXqFGXKlOGBBx4gOTk5It8vEiShC/6W1DBo2+mDSR5G4tyDrR407sP2PFw31qxT0+Nd5tYP30hd8edl/PjxEf8e9erVY/Xq1QDs2LGD3r17c/78eQYOHBjx7+0GSegxKK//dJH4j3TVZRWCtu14PPjNxmj8pw6mReUWxn3Ynoda7cw6NT0+jh08eJAhQ4awa9cuAF544QU6dOgQdP8BAwZw8803c8cdd1C7dm2Sk5P59NNPOXv2LB9++CGNGjXi4MGD3HPPPRw+fJg2bdqwcOFCVq5cSYkSJbjrrrvIyMggMzOTxx57jLvvvjvP+OrWrctzzz3HX//6VwYOHMiRI0e477772LFjByVLlmTKlCk0a9aMpk2b8u2331KuXDkqVqzI888/z7333kv//v1JTk4mIyODTz75hBMnTrB9+3Z69erF008/TWZmJn/84x9ZsWIFSinuu+8+HnroIaNzKtUWBSt3HmHlziO2bWkH0kg7kOZtQA5s/WUrW3/ZatTHln3H2LLvWM6Nu36wXk7t32i9CqmTJ0/SokWLrNfYsRd+Y3nwwQd56KGHSE1N5aOPPmLQoEFh9V2xYkVWrVrF0KFDefbZZwF44okn6Nq1K6tWraJXr15ZPywWLlxItWrVWLNmDevXrycpKbTfPFu1asXmzdZajMcff5yWLVuydu1aJkyYwL333gtAhw4d+O6779iwYQN169bl22+/BWDZsmW0b98egLS0NGbPns26deuYPXs2u3fvJi0tjT179rB+/XrWrVvnym8BcoUueHrhFsB+7PjFVS8CsT8PfcIPEwCzOMfOXw8EnIcvfb/mOx0DXzDK7PgCrkSJEqSlpWV99o+PAyxevJiNGy/8sPvtt984duxYYBdB9e7dG4CrrrqKuXPnArBkyRI+/vhjAJKSkihfvjwATZs2ZeTIkYwePZqbb76Za665JqTvkX0l/ZIlS/joo48A6Nq1K4cPH+bo0aNcc801fPPNN1x22WUMHTqUKVOmsGfPHipUqEDp0tYN9uuuu45y5ayFe40bN2bnzp1ceeWV7Nixg+HDh9OjRw+6d+8e8p89GEnoBVQowx2xcLPSK39t/VfjPh696QoXIgnQPfLjvgXV+fPnWbp0KSVKlMh/ZxvFixcHICEhgXPnzgE5E3B2DRo0YOXKlSxYsIAxY8bQvXt3brjhBu6/3yqeNn78eJo1y70aePXq1VxxxRVB+1ZK0alTJ1599VV27drFP//5Tz7++GPmzJmT44eGP9bs8ZYvX541a9awaNEiXn31VT744APefPNNR+fCTxK6iAtNKjYx7qN5zYvNAwlU/Sr3+zQQS/c9unfvziuvvMKoUdZvMWlpabRo0cKoz44dO/LBBx8wevRovvjiC3755RcA9u7dS4UKFejXrx+lS5dmxowZjB07NsdvD+np6Tn6Sk9PZ+TIkQwfPhyATp068e677/LYY4+RkpJCxYoVKVu2LGXLluXQoUOcOXOGunXr0rFjR5599tk8Z/IAHDp0iGLFinH77bdTr149BgwYYPRnB0noBU4oV92x9J/WK27UnMmrpo1jprVg4thLL73EAw88QLNmzTh37hydOnVi8uTJRn0+/vjj9O3bl9mzZ9O5c2eqVq1KmTJlSElJYdSoURQpUoSiRYvy2muv2R6/fft2WrZsmTVtcfjw4Vlj2+PGjWPgwIE0a9aMkiVLMnPmzKzj2rVrR2ZmJgDXXHMNY8aMoWPHvBeV7dmzh4EDB3L+/HkA/vWvfxn92UGqLcYUfyI2HSoJtx+7B1z4+7i2yxzAfmzarXiNjLOS78AqlQGYvu9AGMcezfHR9kEfpg+4MD3ewKZNm7KGCwqL06dPk5CQwEUXXcTSpUsZOnRojqvwgsbu71CqLYo8jb2lcdC20W1HexiJc6OP/GLch+15SDK8ajI9XoRl165d3HXXXZw/f55ixYoxderUaIfkqZASulIqCXgRSACmaa0nBrR3AeYDvlqhzNVay92gAiKvIYZYL5vr1+jRQ6HvPM7+z2t7HkyHSmSoxVP169fPWhhUGOWb0JVSCcCrwPVABpCqlPpEax04ufZbrfXNEYhRRNiSrVYy7Fi/Yq62pXutYYirq7m4HD4C1h+yphya3Bxds/tXIODm6PavrPd61zrrdM9K6z3Gbo6K+BTKFXpbYJvWegeAUmoW0BMovKsl4szL/2ctyLFL6FPWTgFiP6H/e8W/AbN56BMWbAICxtC/sRasOE7oX/gW0hTSeejCW6Ek9OrA7myfMwC79cxXK6XWAHuBkVrrDS7EJ0RIHm33qHEf43uaT33M5aZn3O9TiCBCSeh2RXkDp8asAi7TWv+ulLoJmAfkqheqlBoMDAaoVatWeJEK1zSd2TTH5xP7B/u2X3jQchnfjfUV+3Mesy55XeQDdKB+efPytA2rlHEhkgCXBr/h7Kkg9w3M+z2a/z7CM6Ek9Awg+4Maa2BdhWfRWv+W7esFSqlJSqmKWutDAftNAaaANW3RcdQiJMHmo5eJw5ls/nozJkW6/PVs8ipWFjZ/HZhCWqRLKUW/fv14++23ATh37hxVq1alXbt2fPbZZ1GNrUuXLjz77LO0bm07A7BACiWhpwL1lVJ1gD1AH+Ce7DsopaoA+7XWWinVFqvo12G3gxXu8l9tZ82/Th6e1RY4D33F/theM+BGzZm8ato4ZloLxm1uXVGHeMVfqlQp1q9fz8mTJylRogT//e9/qV69ujsxiFzyTeha63NKqWHAIqxpi29qrTcopYb42icDdwBDlVLngJNAHx2tFUsi34U+TWc+kuPzhN5Ng+wJY6+2burdOu9W88AiyB+nCdvzcMsLZp2aHh8HbrzxRj7//HPuuOMO3n//ffr27ZtVkTBYSdpx48axa9cuduzYwa5duxgxYgR/+ctfAHjuueeyap4MGjSIESNGkJ6eTlJSEu3atWP16tU0aNCAt956i5IlS/Lll18ycuRIzp07R5s2bXjttddy1FYB+OKLL3j88cc5ffo09erVY/r06VmFtQqSkMrnaq0XaK0baK3raa3/6ds22ZfM0Vq/orW+UmvdXGvdXmv9fSSDFu6qV6l00Meu1SlXx+ixbl5xI07b81Cxvtnj40yPjwN9+vRh1qxZnDp1irVr19Ku3YXhp2AlaQE2b97MokWLWL58OU888QRnz55l5cqVTJ8+nR9++IFly5YxderUrHnnW7ZsYfDgwaxdu5ayZcsyadIkTp06xYABA7JK1547dy7Xsv9Dhw7x5JNPsnjxYlatWkXr1q157rnnvDk5LpN66ILFG/ezeON+27aU3Smk7E7xMhxHUvelkrov1aiPZTsOs2xHwEjhlv9YL6fSl1ivQqxZs2akp6fz/vvvc9NNN+VoW7JkCf379wdylqQF6NGjB8WLF6dixYpUrlyZ/fv3s2TJEnr16kWpUqUoXbo0vXv3zrrar1mzZtYDMvr168eSJUvYsmULderUoUGDBgAkJyfzzTff5Ihh2bJlbNy4kQ4dOtCiRQtmzpzJzp07I3pOIkWW/gumfrsDgG6NL83VNnPDzFzbYtGktEmA2Rj68//9EQgYQ//eVzGv4Y3OOv3Kt/Q/VsbQo+TWW29l5MiRpKSkcPjwhR+awUrSgn3J2bxGcv3HZf8cysiv1prrr7+e999/P999Y50kdBEXxncwrzTxzB3NXYgkQM+8S6h6LlLTF/Nx3333Ua5cOZo2bUpKSkrW9mAlaYPp1KkTAwYM4JFHHkFrzccff5w1g2bXrl0sXbqUq6++mvfff5+OHTvSqFEj0tPT2bZtG5dffjlvv/02nTt3ztFn+/bteeCBB7L2OXHiBBkZGVlX9QWJJHQRF2qWqZn/TvmodUlJFyIJUCH27z94oUaNGjz4YO4HeedVktZOq1atGDBgAG3btgWsm6ItW7YkPT2dK664gpkzZ3L//fdTv359hg4dSmJiItOnT+fOO+/Muik6ZMiQHH1WqlSJGTNm0LdvX06fPg3Ak08+KQldiGhxo+ZMXjVtHDOtBeOWKC0A+v3333Nt69KlC126dAGgQoUKzJ8/P9c+48aNy/F5/fr1WV8//PDDPPzww7mOKVKkiG099euuu862YFf23xS6du1KaqrZPZhYIAldxAU3as7kVdPGMdNaMEKEQRK64Pm7WwRt+9c11k296+dc71E0zvjjNGF7Hnq/btap6fEiJLVr185xFV9YSUIXVLs4+EN6q5Sq4mEkzrkRp+15KFfDrFPT44UIgyT0AiywyJZTn66xSvPc0rxarraFPy105XtE2pI91lzvjtXzfo5jXlK2WI+v69Kw8oWN6z+y3pvc7qzTrYut9/rdHMclRKgkoQveWWYtorBL6LO3zPY6HEfeWPcGYJbQX0vZDgQk9FRribnjhL7keetdErrwgCT0OBBuSdtgVRgLsmc6m9cdf/meli5EEuCON93v0wG3fpsLFKvllAsrSegiLlQs4WBmSsAim8pBdsva18nUvzK5V98WJgkJCTRt2pSzZ89y0UUXkZyczIgRIyhSpAgrVqzgrbfe4qWXXgq73/T0dG6++Wa5ERpAErqIC/56M11qdnHcx+LMVgB0S1hlHpCfvw6M09IBLnPrijrUK/4SJUqQlpYGwIEDB7jnnns4evQoTzzxBK1bt46rWuSxQIpzibgwc8PM0OvOjDtq+5paYwJTa0zIuf0y52PygFUL5vsYW/4fJZUrV2bKlCm88soraK1JSUnh5put58qPGzeO/v3707VrV+rXr8/UqVMBq87KqFGjaNKkCU2bNmX27Nz3dDIzMxk1ahRt2rShWbNmvP564Z0qKlfogtf6BX8i/XNdrDKinWZ38iocR/xxmrA9D3e9Bc/Udd7pXW85PzYO1a1bl/Pnz3PgwIFcbWvXrmXZsmUcP36cli1b0qNHD5YuXUpaWhpr1qzh0KFDtGnThk6dcv5bfOONNyhXrhypqamcPn2aDh060L17d+rUKXxlFyShCyqUKha0rXxieQ8jcc6NOG3PQ6lLzDo1PT4OBauA2LNnT0qUKEGJEiW49tprWb58OUuWLKFv374kJCRw6aWX0rlzZ1JTU2nWrFnWcV988QVr165lzhzr6VpHjx5l69atktBF4fThit0A3Nk6d4GredvmeRyNM4t3WvO9u13mfHrgwvU/A5DUpOqFjavfNYqLjZ9Y741j+4lPXtmxYwcJCQlUrlyZTZs25WgzKX/78ssvc8MNN7gaa0EkCV0wZ2UGYJ/Q52/LXTgpFr27yUq8Jgl9+nfpQEBCT3vPJCz4wTeeGyMJPVLTF0Nx8OBBhgwZwrBhw3Ilb4D58+czZswYjh8/TkpKChMnTiQzM5PXX3+d5ORkjhw5wjfffMMzzzzDqVOnso674YYbeO211+jatStFixblxx9/pHr16pQqVcrLP15MkIQu4sJLXcOf+hZoanIEZlz0NfyBUMCdPHmSFi1aZE1b7N+/v22lRIC2bdvSo0cPdu3axWOPPUa1atXo1asXS5cupXnz5iilePrpp6lSpQrp6elZxw0aNIj09HRatWqF1ppKlSoxb948b/6AMUYSuogLZYqVMe6jbGJRFyIJkBidB0oEitYCoMzMzKBt2cvoAjRo0IApU6bk2EcpxTPPPMMzz+RcOJa9GFeRIkWYMGECEyZMcC/wAkoSeiEWuGK0IK8g9decSaqT5LiPvGraOGZaC0aIMEhCF3HBX3PGJKHnVdMGCP/xbeOOmteCKSQCH2ghnJGEXgilT+yR4/PJM9avxSWKJeTa9+S5rgC0fbdt5AMzMKnbJOM+Zgy0+TP+4UOYUDX39lD94UPnx7pAa217A1LEvlBm+ASShC5sE3lW20XBa6XHEjfitD0PxUqGX8Ml+5V8sQg8pzREiYmJHD58mEsuuUSSegGjtebw4cMkJiaGdZwkdMHbS9MB6H917VxtszbP8jYYhz7d/ikAt9S7xXEfH6+2pm/2apntoRTLrSXotP2Ts07X+JaqN7/bcVxO1ahRg4yMDA4ePOj59xbmEhMTqVEjvAekSEIXfLbWWlBjl9AXpS/yOBpn5m6dC5gl9FnLrQVWORL6hnnWu9OEvsq39D8KCb1o0aKFcrVkYSYJXcSFKd2n5L9TPt4Z1M6FSALcO8/9PoUIQhK6iAtFi5jPIS+aEIHiowkRmNsuRBBSPlfEhXnb5hnXnflwxe6sujauWf2ueT0YIUIkCV3Ehfnb5hvXnZmzMiOrro1r0t4zrwcjRIhCGnJRSiUBLwIJwDSt9cQg+7UBlgF3a63nuBaliKjZ918dtG160nQgukWdQuGP04TteRhouHrW9HghwpDvFbpSKgF4FbgRaAz0VUo1DrLfU0DBmBYhhBBxJpQr9LbANq31DgCl1CygJ7AxYL/hwEdAG1cjFBE35ZvtAAzuVC9X24z1MzyOxpk5P1q/EN7R4A7Hfby/fBcAfdvWurDxO18Vxw5/cdbpyhnW+1UDHMclRKhCSejVgex3ijKAHPO7lFLVgV5AV/JI6EqpwcBggFq1agXbTXjsy03W48DsEvrXGV97G0y49VJ8FqZbxblMEvpna63iXDkS+o++XzidJvT11vx4SejCC6EkdLs1w4FFBl4ARmutM/NaYqy1ngJMAWjdunX4hQqECGJa92nGfbw7qL0LkQRI/sT9PoUIIpSEngFkf5RNDWBvwD6tgVm+ZF4RuEkpdU5rPc+NIEUhFG79FCFESAk9FaivlKoD7AH6APdk30FrnbW+WCk1A/hMknl8yj7bpcwV/m2P5HmMFw9X8Nec6dOoj+M+8qpp45hpLRghwpDvLBet9TlgGNbslU3AB1rrDUqpIUqpIZEOUEReYtEEEovaV1wsflFxil9U3OOIwpeSkUJKRopRH4s3HWCx735ClqKJ1supHxdaLyE8ENI8dK31AmBBwLbJQfYdYB6W8NLM+4LXOp/czfavGbjwhKPA+up+Xs5dzyvOUNmeh34fmXVqerwQYZCVokIIESckoQte+nIrL3251bZt8prJTF5jfvUbae9sfId3Nr5j1MebS37izSU/5dz49dPWy6llr1kvITwgCV3w3bZDfLftkG3bDz//wA8//+BxROFzI87vtx/i++0B52HH19bLKdPjhQiDlM8Vxvxj6YH8s2DCOTY9MXifwcbqAV6+7uX8v1k+piVHYJHzPQXjiU8iPsgVuhBCxAm5QheO5XXFDPnPT7fta1zuvoP9BpCdv+bMgCYDQv6egfKqaeOIkzIGsqBKGJCELihfsljQtouLX+xdIAbWHFxj3Meqnb/m3liyvHG/QnhFErpgcv+rgrY9f+3zHkbinBtx2p6Hux3MnHFyle2wKJkQ2UlCjxFNZzYNeSm9EELYkZuigqcWbuaphZtt215Y+QIvrHzB24AcmLZuGtPWmVVcnJSyjUkp23JuXDzOejn17XPWSwgPyBV6jDm2aWK+NxvdtmrnL0Hb3Bib9sKWI1uM+9i497fcG3enmnW6L/KFyYTwk4Qu4sIznZ8x7uOVe1q5EEmAO82fdSpEqGTIRQgh4oQkdBEX3Kg5k1dNG8dMa8EIEQYZchFULRe83velpS71MBLn0n9LN+5jx8Hfc28sW82s00Mu/4AQIg+S0AUv9GkZtG3iNRM9jMQ5N+K0PQ+3TzXr1PR4IcIgCd1DeS1hD6WQlRBC5EXG0AVPfLqBJz7dYNv21PKneGr5Ux5HFL5XVr/CK6tfMerjuS+28NwXAdMf//OI9XLq//5pvYTwgFyhR4HdPHP/6lCv56BDkPnXPpuP2C84Ckdej6LLtTq2Ti3rfWbTsB4uve/4PqfhZdl79JRNx4bzyH/bY3a8EGGQhC7iwpMdnzTu49k7m7sQSYDbJrnfpxBBSEIXEXNsk3WjMq/fOnI9aHpcOZr6r9KFEGGRMXQRF9yoOZNXTRvHTGvBCBEGuUIX1K1UKmjbZWUv8zAS5349/at5HyfO5N54ieHDLk4cMTteiDBIQhf8q3ezoG3j/mecd4EYcCNO2/Nw60tmnZoeL0QYZMhFCCHihCR0wZi5axkzd61t27jvxzHu+3HeBuTAs6nP8mzqs0Z9/PPzjfzz8405N37yF+vl1KK/Wy8hPCBDLoIdB48Hbdv5204PI3HuVKbNHPJw+zh7PvfGw9vNOj1nHpcQoZKELuLCP9r/w7iP/72tiQuRBOjxb/f7FCIISehCxJJwHxbt5IHUIm7JGLqIC27UnMmrpo1jprVghAhDSFfoSqkk4EUgAZimtZ4Y0N4T+F/gPHAOGKG1XuJyrCJCGlcrG7StUYVGHkYSg6oEr0PjqnCvtMO9kheFQr4JXSmVALwKXA9kAKlKqU+01tmnA3wJfKK11kqpZsAHQCHPBAXH47dcGbRtdNvRHkbinBtx2p6HGw3rrJseL0QYQhlyaQts01rv0FqfAWYBPbPvoLX+XWutfR9LARohhBCeCiWhVwd2Z/uc4duWg1Kql1JqM/A5cJ9dR0qpwUqpFUqpFQcPHnQSr4iAEbNWM2LWatu2R759hEe+jf0x4CeXPcmTy8wqLj42bz2PzVufc+NHf7JeTn3+V+slhAdCGUNXNttyXYFrrT8GPlZKdcIaT+9ms88UYApA69at5So+RvxsVwfcZ//x/R5G4lxiQvDnoobcR1Gb65vf9pp1epF5XEKEKpSEngHUzPa5BhD0X7nW+hulVD2lVEWt9SHTAIUIxcg2I437+HuPxi5EEuAGeVqR8E4oQy6pQH2lVB2lVDGgD/BJ9h2UUpcrpZTv61ZAMeCw28EKIYQILt8rdK31OaXUMGAR1rTFN7XWG5RSQ3ztk4HbgXuVUmeBk8Dd2W6SChFx/nozJlUX/fVs8qo+GTZ/HRipuig8ENI8dK31AmBBwLbJ2b5+Coj9JwkLW60uKx+0rXmlCDyWLQIuLn6xeR8li+XeWLONWaclK5gdL0QYZOm/YHRS8CUDI64a4V0gBtyI0/Y8dBtn1qnp8UKEQZb+CyFEnJArdMGQt1cCMLn/VbnaHvrqIQCev/Z5x/37HwQdSf9YYlVbfLKj87noIz9cA8Czd2YbZprdz3q/+x1nnc77s/V+2yTHcQkRKknogl/snqXp48azOr1QpVQV4z6qlbOZM37iF7NOy+ZagydExEhCd1nTmcGLOZW5wr9P7K+8dEP6xB6efa9hLYcZ9/Fw94YuRBKgqzytSHhHxtCFECJOyBV6hKxLXpdrm38s2csr18LCX29m4jXOqxv669m80KelKzEBF+rA3D7VvT6FCEISuqDD5RWDtrWr2s6sc4/qdtcuW9u4j7qVStts7GzWacX6ZscLEQZJ6IK/XBc86QxpPsTDSJxzI07b89D5b2admh4vRBgkoQtvhPNEnjxuLAshgpObooLkN5eT/OZy27Yhi4cwZHHsX6WP+noUo74eZdTHsPdWMey9VTk3vnO79XLqw4HWSwgPyBW64NTZzKBtp8+d9jAS5xpWMJ9yaPts1bPBa8WHxKtnkgqBJHQRJwY1HWTcx5+7XO5CJAGuedj9PoUIQoZchBAiTkhCF3Hhoa8eyqo749SQt1dm1bVxzex+F+rBCBFhMuQiuO6KykHbOtcwnIftETfqtre67OLcGxvcYNZpjbZmxwsRBknogsGd6gVtG9BkgHeBGHAjTtvz0OEvZp2aHi9EGGTIRQgh4oQkdMHdry/l7teX2rYNXDiQgQtjfx718C+HM/zL4UZ9DJqZyqCZqTk3Tu9hvZx6r4/1EsIDMuQiYpa/FLFXZYf/p17wmjaOmdaCESIMktCF8LmvYx33O20/1P0+hQhCErqIOYGlh0MpO5zXg0WEKCwkobvEn3T8wwNePEdTuMtfz2bmfS5ONfTXgen3kXt9ChGEJHTBzc2qBm27obbhPOwCpJvdfPwrbzPrtEGS2fFChEESeoQUpKcS9b+6dtC2Po0KzwwN2/PQ9k9mnZoeL0QYZNqi4OSZTE6esa+4ePLcSU6eO+lxRDHkzAnrJUQBIFfoggHTrbHj2fdfnavtz4v/DMD0pOmexhQNf5i2DIB3B7W/sPHdO633gQ7vicy81XpP/sQgMiFCIwldCJ+bm1Vzv9Mmvd3vU4ggJKEL4dO3bS33O71qgPt9ChGEjKELIUScCCmhK6WSlFJblFLblFK51l8rpf6glFrre32vlDKvZSqEx/KqaeOYaS0YIcKQ75CLUioBeBW4HsgAUpVSn2itN2bb7Segs9b6F6XUjcAUoF0kAhbuu+OqGkHbel7e08NIosv2PLS4x6xT0+OFCEMoY+htgW1a6x0ASqlZQE8gK6Frrb/Ptv8yIHiGEDHnztY1g7bddvlt3gUSZbbnoeUfzDo1PV6IMIQy5FId2J3tc4ZvWzB/BP5j16CUGqyUWqGUWnHw4MHQoxQRdeT4GY4cP2Pb9supX/jl1C8eRxQdZzPPczbzfM6Nxw9bL6cyz1ovITwQyhW6stmmbXdU6lqshN7Rrl1rPQVrOIbWrVvb9iG8N/Qd6zmadvPQH06xnlpfGOah95v2AxBwHj6413p3Og/9rdvMjhciDKEk9Awg+++iNYC9gTsppZoB04AbtdYGlzRCREeftsGHnhxrda/7fWY3rlyY+x+NTBwiJoSS0FOB+kqpOsAeoA+Q406PUqoWMBfor7X+0fUohfBAr5YRuPXT/G73+xQiiHwTutb6nFJqGLAISADe1FpvUEoN8bVPBsYClwCTlFIA57TWrSMXtiiM8ipJ7C9bbMJfz6ZEsQTzzvz8dWCKlXSvTwj/SjvcK3lRIIW0UlRrvQBYELBtcravBwGD3A1NCG/lVdPGMdNaMEKEQZb+C/q1vyxo290Noz9kkF8pYrceJmJ7HtrcZ9ap6fFChEESuuCW5sGLUiXVKTwPaLA9D01uN+vU9HghwiC1XAR7fz3J3l/ta57vO76Pfcf3eRxRdPx26iy/nQqYM340w3o5deqo9RLCA3KFLnhodhpgP3Y85tsxQOGYh/6nmSuAgPMw937r3ekY+Pv3mB0vRBgkoYu40nRm07CPWZe8DoCBHWq7HA3Q7n73+xQiCEnoQvgkNQn+sGzHGt/qfp9CBCEJXcSF3398jFWPXU/5xPIhHxN4Ne+vZ1OhVDH3AvPXgSl1iXt9ChGE3BQVcSGx+jtZdWecGvrOyqy6Nq754N4L9WCEiDC5Qhf86Zq6QduSr0z2MBLnzhy5huRb2hj1YXse/meYUZ/GxwsRBknogm6NLw3a1qVmF+8CMZD5e2PjWG3PQ8Mbjfo0Pl6IMMiQi2D7wd/ZfvB327afjv7ET0d/8jii8KmEYxw6eciojwPHTnHg2KmcGw9ttV5OHdtvvYTwgCR0waNz1/Ho3HW2beOXjmf80vEeRxS+xOrvMerrUUZ9DH9vNcPfW51z46cjrJdTc+6zXkJ4QIZcRFw4c7gLf+zZ1qiPoV3quRRNNh0fcr9PIYKQhC7iQubxhnSsbvugrJB1aVjZpWiyqd/N/T6FCEKGXERcUBf9alxzJq+aNo6Z1oIRIgyS0EVcSKw2O6vujFMPzU7Lqmvjmrn3X6gHI0SEyZCLYHjX+kHbBjcb7GEkzp051JXBt7Uz6sP2PHQaadSn8fFChEESegjceoBCrOpYv2LQtqurufj0ngjKPFHfOFbb81DvWqM+jY8XIgwy5CLYsPcoG/ba1+zefGQzm49s9jii8Kmih9l9bLdRH7sOn2DX4RM5N/681no5deQn6yWEB+QKPQz5PQoNoOnMRzyIxF3jP90I2NdDf2r5U0Ds10NPrDqHsd99ZRTnqDlrgIDzsNA3Lu+0nvn8YWbHCxEGSegiLpw5dD1/7t3eqI+Hrm/gUjTZXGt2o1aIcEhCF3Eh80Rd2lQxK87Vvm4EStzWNpsbL0Q4ZAxdxAVV7KBxzZm8ato4ZloLRogwyBV6HvwPQChzhf9zwRsfLywSq8xl/NKvjcbQ/fVs7O4lOOavAyNj6MIDktAFf0tqGLTtwVYPehiJc6cPJvHgHf9j1IftebhurFGfxscLEQZJ6CE4tmkiENosl4LoqssqBG1rUbmFd4EYOH/yMuNYbc9DLbPFSsbHu21cOQfH2E9pFbFHxtAFK3ceYeXOI7ZtaQfSSDuQ5m1ADhQpvo+tv5iNVW/Zd4wt+47l3LjrB+vl1P6N1ksID8gVuuDphVsA+7HjF1e9CMT+PPTil85nwg9LjOIcO389EHAevvTVgnc6Br5glNnxbnFyle3kal5ElSR0ERdOH7iJv95lNkXw0ZuucCmabLrH/sNBRPyQhC7iwvlTNWlSsYlRH81rXuxOMNlVv8r9PoUIIqQxdKVUklJqi1Jqm1Iq19w9pVQjpdRSpdRppZSUlxOeK1J8r3HNmbxq2jhmWgtGiDDke4WulEoAXgWuBzKAVKXUJ1rr7Hd6jgB/AW6LRJAihsTouGrxSz/lqeXfG42h51XTxjHTWjBChCGUIZe2wDat9Q4ApdQsoCeQldC11geAA0qp+JzXF+fG3tI4aNvotqM9jMS50/tv4ev9UDsl78RpN/XUv4Ask6q+zz9ntTU8ewaALb59sluXbP9g7RyS/pX/PkK4JJSEXh3IXpc0A3A0uVYpNRgYDFCrVi0nXYgIuLJa8KvuRhUa2TfE2Nzk86erGfeRkPhzrm1bihcz67RqM7PjhQhDKAld2WzTTr6Z1noKMAWgdevWjvoQ7luy9RBg/4CHpXuXArH9oIv0iT1Yf8iachjsxqjdQ0oCr7DX7P4VCLg5uv0r6z3bgyqa2lytB7VnpfUuN0eFB0JJ6BlAzWyfawB7IxOOiIaX/89akGOX0KesnQLEdkIH+PeKfwNm8+UnLNgEBIyhf/Os9e70yUNf+Jb+yxi68EAoCT0VqK+UqgPsAfoA90Q0KiHC9Gi7R437GN/TbNqjrZuecb9PIYLIN6Frrc8ppYYBi4AE4E2t9Qal1BBf+2SlVBVgBVAWOK+UGgE01lr/FrnQhbigfvngD7oOVcMqZVyIJMClwW84C+G2kBYWaa0XAAsCtk3O9vU+rKEYIaLCX2/GpECXv55NXsXKwuavAxNrRbpEXJKVoiIuuFFzJq+aNo6Z1oIRIgyS0AUTegeftTH26oJRz9uNOG3Pwy0vmHVqerwQYZCELqhXqXTQtjrl6ngYiXNuxGl7Hioajs2bHi9EGKQeumDxxv0s3rjfti1ldwopu1O8DMeR1H2ppO5LNepj2Y7DLNtxOOfGLf+xXk6lL7FeQnhArtAFU7/dAUC3xpfmapu5YSYAXWp28TKksE1KmwSYjaH3mbIs17ZZxf7XajtzPmtbmXCq7H7lW/ovY+jCA5LQRVwY3yFG6473fCXaEZgLtyBbjJWFKEwkoYu4ULNMzfx3ClGOAl7TrSv/9IE9bMsH5KtCwbgHIeKDJPTCzH/ldfofvs9JufepUjnnvjEqZmvO2NSCKTDCvdKO8X8jhYEkdBEXYrbmjGktGCHCIAld8PzoYdYXF4/K1fav4/usL0pV8TCi8P3rmtDqjoc9bNL7dQfRuHi8EGGQhC6odnGJoG1VYjyR+0UsznLBK1qEVUbXJ6SHYgjhkCR0wadrrGrItzTP/ZCIhT8tBCCpjs34egxZssea692xekfbdrsnFQVK2XIg98b1H1nvTW53FFeHEycB+K5k8B+aQrhFErrgnWU7AfuEPnvLbCD2E/ob694Agif0ULyWsh2ALg0rX9iY+qb1ni2hh3WVPd36QdKUXY7jEiJUktAJPq4a1gISEVXPdDavO/7yPS1diCTAHb4fCHO7ud+3EAEkoYu4ULFE7qcthatymUQXIglQJvfqWyEiRRJ6NoHjrE1nPmK7XcQef70ZkxIF/no2diUQHDOpAyNEmApNQs9rRoJ/aMWfwEXB40bNmbxq2jj2vW/pv5TBEx4oNAldBPdav+BPpH+uy3MeRuKcG3Hanoe73jLr1H/8nC5m/QgRgkKX0O1mKPhvihbWoZUKpYoFbSufWN7DSJxzI07b81DqErNOA46XuesikgpdQhe5fbhiNwB3ts5d4GretnkA3Hb5bR5GFL7FOxcD0O0y57NJFq7/GYCkJlUvbFz9rvXe8g9Zm0JZbZp1cbDxE8fxCBEuSejxxGFxpDkrMwD7hD5/23wg9hP6u5usxGuS0Kd/lw4EJPS096z3bAk9LD9YS//XDQz/KtvJ1bwo3OI+ofuvpvw3Ph2VQBUx76WuLxn3MTW5dZ7toQzJ5fr31fc9k5CECEvcJ/RCKdyyp68vjUwcHipTrIxxH2UTi7oQSYBEKSkrvFPoEnphvfEZ79yoOZNXTRvHDGvBFEjyhKOoKXQJXcQnN2rO5FXTJlz+oZdZxaySBH3eyb0KVS4uhNskoQtmDGwbtG1St0keRuKcG3Hanoc/fGjU54AzfzM6vkBx+oQjJzfz5areVoFL6OHe+ZcCW/krUSwheNtFBaPsqxtx2p6HYiXD6sPRjVMhXFLgErpw39tL0wHof3XtXG2zNs8CoE+jPh5GFL5Pt38KwC31bnHcx8errembvVpme6jF8qnWe9s/Oet0jTUURPO7HcfldPpizC9IcnKVLc8tzVOBTeih/mMt0KtAPfrH+9laa0GNXUJflL4IiP2EPnfrXMAsoc9abi2wypHQN8yz3p0m9FW+pf82CT2/K3XT3y7jelWq3Hi1VWATuhDZTek+xbiPdwa1cyGSAPfOc3yo0+QqC5I8ZHLRFYEfMiEldKVUEvAikABM01pPDGhXvvabgBPAAK31KpdjLbwKydWFiaJFzOeQF02IQEnEhNxx5ffboukYu5MfBAXmh4BXN14L6P+5fBO6UioBeBW4HsgAUpVSn2itN2bb7Uagvu/VDnjN9y6EJ9yoOZNXTRvHbGrBxLJYHaZx/AOnTi3W/eTB4//C+QEQwaHUUK7Q2wLbtNY7AJRSs4CeQPaE3hN4S2utgWVKqYuVUlW11j+7HrEQNtyoOZNXTRvHTGvBFAAxf3XvJNkW0JuvysrBeeyg1B1AktZ6kO9zf6Cd1npYtn0+AyZqrZf4Pn8JjNZarwjoazAw2PexIbAljFgrAofC2D9aCkKcBSFGkDjdVhDiLAgxQnTjvExrXcmuIZQrdGWzLfCnQCj7oLWeAji6e6WUWqG1zrt6UgwoCHEWhBhB4nRbQYizIMQIsRtnKHeBMoDsv4PWAPY62EcIIUQEhZLQU4H6Sqk6SqliQB8gsGr/J8C9ytIeOCrj50II4a18h1y01ueUUsOARVjTFt/UWm9QSg3xtU8GFmBNWdyGNW1xYARiNZ9o7I2CEGdBiBEkTrcVhDgLQowQo3Hme1NUCCFEwRCBlRRCCCGiQRK6EELEiQKV0JVSdyqlNiilziulYmrKkFIqSSm1RSm1TSn1SLTjsaOUelMpdUAptT7aseRFKVVTKfWVUmqT7+/7wWjHFEgplaiUWq6UWuOL8Ylox5QXpVSCUmq1b81ITFJKpSul1iml0pRSK/I/wnu+RZNzlFKbff8+r452TNkVqIQOrAd6A99EO5DsspVHuBFoDPRVSjWOblS2ZgDOH+njnXPAX7XWVwDtgQdi8HyeBrpqrZsDLYAk3wyvWPUgsCnaQYTgWq11i1ic4+3zIrBQa90IaE6MndMCldC11pu01uGsLvVKVnkErfUZwF8eIaZorb8BjkQ7jvxorX/2F3fTWh/D+k9TPbpR5aQtv/s+FvW9YnKGgVKqBtADmBbtWAoypVRZoBPwBoDW+ozW+teoBhWgQCX0GFYd2J3tcwYxloAKKqVUbaAl8EOUQ8nFN4yRBhwA/qu1jrkYfV4A/gacj3Ic+dHAF0qplb4yIbGmLnAQmO4bvpqmlCoV7aCyi7mErpRarJRab/OKuSvebEIqfSDCo5QqDXwEjNBa/xbteAJprTO11i2wVka3VUo1iXJIuSilbgYOaK1XRjuWEHTQWrfCGrp8QCnVKdoBBbgIaAW8prVuCRwHYup+Wcw94EJr3S3aMTggpQ9cppQqipXM39Vaz412PHnRWv+qlErBuj8RazecOwC3KqVuAhKBskqpd7TW/aIcVy5a672+9wNKqY+xhjJj6X5ZBpCR7TexOcRYQo+5K/QCKpTyCCJEvgemvAFs0lo/F+147CilKimlLvZ9XQLoBmyOalA2tNZjtNY1tNa1sf5d/l8sJnOlVCmlVBn/10B3YuyHo9Z6H7BbKdXQt+k6cpYRj7oCldCVUr2UUhnA1cDnSqlF0Y4JrPIIgL88wibgA631huhGlZtS6n1gKdBQKZWhlPpjtGMKogPQH+jqm8KW5rvCjCVVga+UUmuxfqD/V2sds1MCC4BLgSVKqTXAcuBzrfXCKMdkZzjwru/vvQUwIbrh5CRL/4UQIk4UqCt0IYQQwUlCF0KIOCEJXQgh4oQkdCGEiBOS0IUQIk5IQheFllLq775KiWt9UyPb+bb39bUN8FX2bJbtmPW+cgRCxBxJ6KJQ8pU9vRlopbVuhrUwyF+PJwnwz4HOAP7ufYRChE8SuiisqgKHtNanAbTWh7TWe32rVFsAq3z7fQZcmW11oBAxSxK6KKy+AGoqpX5USk1SSnX2bW8JrNEXVtydB54GHo1GkEKEQxK6KJR8tcyvAgZjlUSdrZQagDXc8p+A3d8D2iul6ngapBBhirlqi0J4RWudCaQAKUqpdUAyUAa4PWC/c0qpfwOjPQ9SiDDIFboolJRSDZVS9bNtagEcAi7SWh+2OWQG1o3TSpGPTghnJKGLwqo0MFMptdFXOa8x8Dmw2G5n36MFXwIqexeiEOGRaotC+CilpgHTtNbLoh2LEE5IQhdCiDghQy5CCBEnJKELIUSckIQuhBBxQhK6EELECUnoQggRJyShCyFEnPh/NUs8csbsC7sAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "plt.hist(noisemarg_OS)\n",
+    "plt.hist(noisemarg_OS/noisemarg_OS_err, histtype='step', lw=2, label='Hellings-Downs', color='C0',\n",
+    "         bins=20, density=True)\n",
+    "plt.hist(noisemarg_OS_mono/noisemarg_OS_mono_err, histtype='step', lw=2, label='Monopole', color='C1',\n",
+    "         bins=20, density=True)\n",
+    "plt.hist(noisemarg_OS_dip/noisemarg_OS_dip_err, histtype='step', lw=2, label='Dipole', color='C2',\n",
+    "         bins=20, density=True)\n",
     "\n",
-    "plt.figure();\n",
-    "plt.hist(noisemarg_OS/noisemarg_OS_err)"
+    "plt.gca().axvline(x=np.mean(noisemarg_OS/noisemarg_OS_err), ls='--', color='C0')\n",
+    "plt.gca().axvline(x=np.mean(noisemarg_OS_mono/noisemarg_OS_mono_err), ls='--', color='C1')\n",
+    "plt.gca().axvline(x=np.mean(noisemarg_OS_dip/noisemarg_OS_dip_err), ls='--', color='C2')\n",
+    "\n",
+    "plt.gca().axvline(x=OS/OS_sig, ls=':', color='C0')\n",
+    "plt.gca().axvline(x=OS_mono/OS_sig_mono, ls=':', color='C1')\n",
+    "plt.gca().axvline(x=OS_dip/OS_sig_dip, ls=':', color='C2')\n",
+    "\n",
+    "plt.legend(loc=\"upper right\")\n",
+    "plt.xlabel(\"S/N\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Amplitude histograms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0.5, 0, '$\\\\hat{A}^2$')"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAEYCAYAAABSnD3BAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/d3fzzAAAACXBIWXMAAAsTAAALEwEAmpwYAAA300lEQVR4nO3deXxU5fX48c8hLAn7vi9BRUEFQQNoQURFiIJ1qVZQELCKWKFu1KW/FiNt3eDrLmBEBK1F6oYbgmKLgAVlR2WpgBECKpsiuwTO7497EyYhy+TOTO7cyXm/XnnN3O3JGSacPHnmuecRVcUYY0ziquB3AMYYY2LLEr0xxiQ4S/TGGJPgLNEbY0yCs0RvjDEJzhK9McYkuLhN9CIyWUS2iciXYZw7XES+EJEVIrJARE4NOTZYRL52vwbHNmpjjIk/Eq/z6EWkB7AXeElVTy/h3Jqq+rP7/NfA71U1XUTqAkuANECBpcBZqvpjbKM3xpj4Ebc9elWdB+wK3SciJ4rILBFZKiLzRaSte+7PIadVw0nqAH2Aj1R1l5vcPwLSyyB8Y4yJGxX9DqCUMoHhqvq1iHQFxgMXAIjIrcCdQOXcfUAzYHPI9dnuPmOMKTcCk+hFpDrwK+A1EcndXSX3iao+CzwrItcCfwYGA1KwHY719o0xplwITKLHGWb6SVU7lnDeq8AE93k20DPkWHNgbrQDM8aYeBa3Y/QFuePw34jI1QDiOMN93ibk1L7A1+7z2UBvEakjInWA3u4+Y4wpN+K2Ry8i03B64/VFJBu4H7gOmCAifwYq4fTeVwIjRKQXcBj4EWfYBlXdJSJ/BRa7zY5R1Xwf8BpjTKKL2+mVxhhjoiMwQzfGGGO8sURvjDEJLi7H6OvXr6+pqal+h2GiJOvnLABSa6Z6a2CH+9l6/TbFnxeHNm7fB8AJDar5HIlJdEuXLt2hqg0KOxaXiT41NZUlS5b4HYaJkqGzhgLwYvqL3hp4sa/zeOVzAHxf0fmxbVytccSxxdo1zy0EYPrN5/gciYmGrT8dAKBp7RSfIzmeiHxb1LG4TPTGFOrNmwG4r0lDIIJfHMZ4dMf0FUDwfnFbojcxN6zDsMga6DEqf3spyZG1V4ZGXhC84SZTtKC+n3E5vTItLU1t6MYYY8InIktVNa2wY9ajNzG3dtdaANrWbeutge9WOY9VagCwuZLzY9uiRouIY4u1r7buBuC0prV8juSYw4cPk52dzcGDB/0OJXByjhwFoGKSfxMWk5OTad68OZUqVQr7Gkv0JuYe+fwRIIIx9Vn35dscHaAx+jHvrgbia0w3OzubGjVqkJqaSkiBQBOGDdv3AnBig+q+fH9VZefOnWRnZ9O6deuwr7NEb4LjfCfh/z65SgknmuIcPHjQkrxHjWr6+/mQiFCvXj22b99equss0ZvgSO0OQGefw0gEluS9qV7F/5Tp5b3zP2pjQmUUMZbdqnvejVPfuGP0rWuF/6erKVzqve/HpN2sh/sWe7x69ers3bs3b3vKlCksWbKEZ555pshrQs/JyMigevXqjBo1itGjR9OjRw969eoVtfhDZWVl0a5dO9q2bcuBAwepXqM6I0eMYPDg4CxBbYneBMe7twMwJkBj9Cb2xowZE/PvceKJJ7J8+XI2bN/LpqxvuOOmQRw9epShQ4fG/HtHgyV6E3O3nXlb6S/K2O0+uj38C0cfay9AY/R3p5/idwhhKakHHq5o/IWwfft2hg8fzqZNmwB44okn6NatW5HnDxkyhH79+nHVVVeRmprK4MGDeffddzl8+DCvvfYabdu2Zfv27Vx77bXs3LmTzp07M2vWLJYuXUpKSgq//e1vyc7O5siRI/zlL3/hmmuuKfJ7Na6ZTOMO7Xjssce46667GDp0KLt27eKGG25g48aNVK1alczMTDp06ED79u2ZP38+tWrVon79+jz++ONcf/31DBo0iMGDB5Odnc0777zD/v372bBhA1dccQWPPvooR44c4Xe/+x1LlixBRLjhhhu44447Ivo3LTHRi0gL4CWgMXAUyFTVJwucI8CTwCXAfmCIqi5zj6W7x5KASar6cEQRm8Dp2LBj5I207HqsvchbKzNntarrdwhx6cCBA3Ts2DFve9euXfz6178G4LbbbuOOO+6ge/fubNq0iT59+rBmzZqw265fvz7Lli1j/PjxjBs3jkmTJvHAAw9wwQUXcN999zFr1iwyMzMBmDVrFk2bNuX9951fULt37y627WruGP2ZZ57J2rXOtOH777+fTp06MWPGDP79739z/fXXs2LFCrp168ann35Kq1atOOGEE5g/fz7XX389ixYtYsKECbz++uusWLGC5cuXU6VKFU455RRGjhzJtm3b2LJlC19++SUAP/30U9ivvSjh9OhzgLtUdZmI1ACWishHqro65JyLgTbuV1ecpfy6ikgS8CxwEc6yfotF5J0C15oEt2LbCiDChL/ps7x59F9XduYPt6kT/3cpLv3WWefGEn5+KSkprFixIm87d/wdYM6cOaxefSxF/Pzzz+zZsyfstq+88koAzjrrLN58800AFixYwFtvvQVAeno6derUAaB9+/aMGjWKe+65h379+nHuuecW2/bBw0cAZ5pjrgULFvDGG28AcMEFF7Bz5052797Nueeey7x582jVqhW33HILmZmZbNmyhbp161K9ujM988ILL6RWLeev1lNPPZVvv/2W0047jY0bNzJy5Ej69u1L7969w37tRSkx0avqd8B37vM9IrIGaAaEJuvLgJfUefWLRKS2iDQBUoH1qroRQERedc+1RF+OPLnM+QMwojH1j4+Nwz4YoDH6R2etA+JrHn28O3r0KAsXLiQlxVvhsCpVnKG9pKQkcnJygPyJOdTJJ5/M0qVLmTlzJvfddx+9e/emT58+3HyzU1dpzJgxdOjQIe/8LW5Rs2+/WE67du2KbFtE6NGjB88++yybNm3i73//O2+99Ravv/56vl8mubGGxlunTh1WrlzJ7NmzefbZZ/nXv/7F5MmTPf1b5CrV7V0ikgp0Aj4rcKgZsDlkO9vdV9R+Y0qv9xjoPYa70u7irrS7/I7GxEjv3r3zzb4J7fl71b17d/71r38B8OGHH/Ljjz8CsHXrVqpWrcrAgQMZNWoUy5Yto2vXrqxYsYIVK1bkDSflalIrmV9+/J5Ro0YxcuRIAHr06MErr7wCwNy5c6lfvz41a9akRYsW7Nixg6+//poTTjiB7t27M27cuBL/atixYwdHjx7lN7/5DX/9619ZtmxZxK8/7A9jRaQ68AZwu7tQd77DhVyixewvrP1hwDCAli1bhhuWKU+anQXA6T6HkYhiNc3Si6eeeopbb72VDh06kJOTQ48ePZg4cWJEbd5///0MGDCA6dOnc95559GkSRNq1KjB3Llz+eMf/0iFChWoVKkSEyZMKPT6DRs20KlTJw4ePEiNGjUYOXJk3oybjIwMhg4dSocOHahatSpTp07Nu65r164cOeIM95x77rncd999dO/evdhYt2zZwtChQzl61Cm38NBDD0X02iHMomYiUgl4D5itqo8Vcvw5YK6qTnO31+Es7J0KZKhqH3f/fQCqWmzkVtQssZSqHn3uLJuCs25adYd058dmbZXKQAS1c8pQPNajX7NmTd6wg1/z6MvaoUOHSEpKomLFiixcuJBbbrnF018KB35xhoJSKvs7YTH0PcwVUVEzd0bNC8CawpK86x1ghDsG3xXYrarfich2oI2ItAa2AP2Ba8N+NcaEcmvePBKgMfp4F28JOVY2bdrEb3/7W44ePUrlypV5/vnnPbWzdbdTCM6vWjdehfNrqRswCPhCRFa4+/4EtARQ1YnATJypletxplcOdY/liMgIYDbO9MrJqvpVNF+AiX/3dLkn8kbSj/0ReI/bow+C0Zee6ncIBmjTpg3Lly+PuJ2mtYKzFkKocGbdLKDwsfbQcxS4tYhjM3F+EZhyKipDLE2OzXyI/wGbY+KpPLGJnN9DNl4FM2oTKAu3OuPU5zSNYJx6w38guSYAX7pT0k6vH/8fyy74egcA3dvU9zkSEw373TH6qgFL+MGK1gRS5irnLsSIEv28cXlP/y9AY/RP/9spxGaJPjF8l8Bj9MbEh0vGAvCnyuGvrGNMNDWr7e0mLr9ZojfB0cj5YDP+Cx8ESFFloSNut/iaMSLCwIEDefnllwHIycmhSZMmdO3alffeey82MYWpZ8+ejBs3jrS042cqJldK8iGiyFmiN8Gxybkhe4VbvTIqxdKML6pVq8aXX37JgQMHSElJ4aOPPqJZs/i/aX7fIWeMvlocLEBSGsGK1pRvbr2bJwM0Rh8YJfTAw28n/L8QLr74Yt5//32uuuoqpk2bxoABA5g/fz5AkaV/MzIy2LRpExs3bmTTpk3cfvvt/OEPfwDgsccey6sJc+ONN3L77beTlZVFeno6Xbt2Zfny5Zx88sm89NJLVK1alY8//phRo0aRk5ND586dmTBhQr7aM+CUS7j//vs5dOgQJ554In959GmqVa8euDF6/5YyN+XG6HNGM/qc0SWfWJxLn8j7ikp7ZeTBK9vz4JXt/Q4jLvXv359XX32VgwcPsmrVKrp2PVaKOrf076pVq3jwwQe5/vrr846tXbuW2bNn8/nnn/PAAw9w+PBhli5dyosvvshnn33GokWLeP755/Pmza9bt45hw4axatUqatasyfjx4zl48CBDhgxh+vTpfPHFF+Tk5BxX/mDHjh387W9/Y86cOSxbtoy0tDRenzIxkOP0luhNzLWu1TryZf/qt8n7ikp7ZeTEBsHr/ZWVDh06kJWVxbRp07jkkkvyHVuwYAGDBg0C8pf+Bejbty9VqlShfv36NGzYkB9++IEFCxZwxRVXUK1aNapXr86VV16Z99dBixYt8hYuGThwIAsWLGDdunW0bt2ak08+GYDBgwczb968fDEsWrSI1atX061bNzp27MjUqVPZkr05kOP0NnRjYm7u5rkA9GzR03sj6z7Iq0e/2B2j79w4/pcJn7P6BwB6ndrI50ji069//WtGjRrF3Llz2blzZ97+okr/QuGlfYur2VVwMW0RKfb80Bguuugipk2blrdv76Ec9h7KiYtFwkvDevQm5qZ+NZWpX00t+cTi/PcZ+M9D8J+HGL9iPONXjI9OcDH2/PyNPD9/o99hxK0bbriB0aNH0759/uGtokr/FqVHjx7MmDGD/fv3s2/fPt566628csCbNm1i4ULnpr1p06bRvXt32rZtS1ZWFuvXrwfg5Zdf5rzzzsvX5tlnn82nn36ad87+/ftZtPwLfvj5YHRefBkK1q8lU75d5tQoH1PJfmyjLlbTLEvQvHlzbrvt+DWFiyv9W5gzzzyTIUOG0KVLF8D5MLZTp05kZWXRrl07pk6dys0330ybNm245ZZbSE5O5sUXX+Tqq6/O+zB2+PDh+dps0KABU6ZMYcCAARw6dAiA+x8YQ/O0Dsd9/3hn/2NMcNR1xuVb+ByGidzevXuP29ezZ0969uwJQN26dXn77bePOycjIyPfdu66qgB33nknd95553HXVKhQodB69hdeeGGhhc7mzp2b9/yCCy5g8eLFRb2MwLBEb4Jjw38AWJjiVBCMqKSCcURrWmU5sefgYQBqJAfr7mxL9CY43Ho3me48ekv0piSpqan5ev2R2rbHGcKxRG9MAQ+dG/lSaFz53LH2Kgbnx/bxazr6HYKJohZ1qvodgifB+R9jAqtxtcaRN1Kr+bH2Im+tzDQN4M01pmiVKwZzomI4SwlOBvoB21T1uALgIvJH4LqQ9toBDVR1l4hkAXuAI0BOUesZmsQ265tZAKS3TvfeyJdvQBVnZsiCqs4YffdmxS+yHA/eXbkVgEvPaOpzJCYaEnmMfgrwDPBSYQdVdSwwFkBELgXuUNVdIaecr6o7IozTBNj0ddOBCBP94sl5T19wx+iDkOj/sehbwBJ9okjYMXpVnSciqWG2NwCYVuJZxpTWtwvyno7tv8HHQBJL+6mxqcPzxeAvij2elJRE+/btOXz4MBUrVmTw4MHcfvvtVKhQgSVLlvDSSy/x1FNPlfr7ZmVl0a9fv6h+ABuqZd1yPkYvIlWBdGBEyG4FPhQRBZ5T1cxofT+TQEp5s079FFutKehSUlJYsWIFANu2bePaa69l9+7dPPDAA6SlpRVaCz4eVEpK0DH6UrgU+LTAsE03Vd0qIg2Bj0RkrarOK+xiERkGDANo2bJlFMMygZaxG17s6zx3e/VRqZ1j8impBx4uL38hNGzYkMzMTDp37kxGRgaffPIJ48aN47333iMjI4MNGzawZcsWNm/ezN13381NN92EqnL33XfzwQcfICL8+c9/5pprrsnX7pEjR7j33nuZO3cuhw4d4tZbb+Xmm2+O6PX9fMAZo6+ZkmBDN6XQnwLDNqq61X3cJiJvAV2AQhO929vPBEhLSyu54pBJPGHevJNbN8cSfeI44YQTOHr0KNu2bTvu2KpVq1i0aBH79u2jU6dO9O3bl4ULF7JixQpWrlzJjh076Ny5Mz169Mh33QsvvECtWrVYvHgxhw4dolu3bvTu3ZvWrb1XPt2+1xmjL5eJXkRqAecBA0P2VQMqqOoe93lvYEw0vp8Jlsd6PhZZA7915wGMPSE67ZWhCQPP8juEwCiqouRll11GSkoKKSkpnH/++Xz++ecsWLCAAQMGkJSURKNGjTjvvPNYvHgxHTocq0Pz4YcfsmrVKl5//XUAdu/ezddffx1Rom+VqGP0IjIN6AnUF5Fs4H6gEoCq5haQuAL4UFX3hVzaCHjLLRFaEfinqs6KXugmKOok14msgWr1otteGapbrbLfIQTCxo0bSUpKomHDhqxZsybfsUjKDD/99NP06dMnanFWDOgYfYlRq+oAVW2iqpVUtbmqvqCqE0OSPKo6RVX7F7huo6qe4X6dpqp/j8ULMPFvxvoZzFg/w3sDy19xvlxzvp3DnG/nRB5YGXhtyWZeW7LZ7zDi2vbt2xk+fDgjRow4LqkDvP322xw8eJCdO3cyd+7cvGGa6dOnc+TIEbZv3868efPyKlfm6tOnDxMmTODwYWdc/X//+x/79u07rv3S2H3gF3Yf+CWiNvxgd8aamHt7vVOF8PKTLvfWwIp/5tt8ZY2T9Hu16hVJWGXi9aXZAFydFt81N2M1zbIoBw4coGPHjnnTKwcNGlRo5UmALl260LdvXzZt2sRf/vIXmjZtyhVXXMHChQs544wzEBEeffRRGjduTFZWVt51N954I1lZWZx55pmoKg0aNGDGjBkRxb1jr5Pka6UE6y81S/QmcJ66oPTzq018OXLkSJHHQssVA5x88slkZuafmS0ijB07lrFjx+bbH1rErEKFCjz44IM8+OCDUYs7tV6CjtEbE29qVK7hdwgJI1rTKsuLpArBHKO3RG8CJyq1c0wgFFxoxG8/7XeGbmpXtaEbY2IqKrVzjPFg5z5L9MYUanyvCBfyvu415/HBJtFprwxNGdql5JN8oKqFznAxxWtdr5rfIYQ1tbQgS/Qm5lIqRliTvXL+D8Aibq8MpVRO8juE4yQnJ7Nz507q1atnyb6UKlTw999LVdm5cyfJycmlus4SvYm5V9e+CkD/tv1LOLMInz+fb/PdsU7P/tJ9+50dcbzu6csLswAYdE6qr3GEat68OdnZ2Wzfvt3vUAJn/y85AFSt7F/qTE5Opnnz5iWfGMISvYm52VmzgQgS/Vcz8m2+WaM6EJLo49h7q74D4ivRV6pUKaIyAOXZNc8tBGD6zcFar9gSvQmOvzjr12Tm/vU8xsoVm7L1jxu7+h2CJ5boTXAkORUDg1U30CQSq0dvTKy59W5m1HBmPlzuYyimfMqtWxTvJS0KskRvgsOtefO2u2bs5T6GYsqnoNQuKki8zMmMtbS0NF2yZInfYZiykruUYGlnz3i9zpgEJCJLVbXQNRiDOeBkjDEmbDZ0Y2JuypdTABhy+hBvDXzqVqtMrgnA6+70yqsijKssZM7bAMCwHif6HImJhmmfbwJgQJdgrWsdzgpTk4F+wDZVPb2Q4z2Bt4Fv3F1vquoY91g68CSQBExS1YejE7YJkk+yPwEiSPT/c+bhU8G5y3SWO0YfhET/8RpnDVRL9InhvVVbgQRM9MAU4BngpWLOma+q/UJ3iEgS8CxwEZANLBaRd1R1tcdYTXk3+B0AJuVu//c130Ix5dMrN57tdwiehLOU4Dxgl4e2uwDr3SUFfwFeBS7z0I4xxpgIRGuM/hwRWQlsBUap6ldAMyB0scxsIJi3lRnPQpeoK7hcXakXvXBr3rxa01l4xGNBBWM8i8faReGIRqJfBrRS1b0icgkwA2gDFFbmrci5nCIyDBgG0LJlsMa/TIxVciv1/c9ZcGRu4wZAMBJ9cqX4q15pvJvjfuZS7hK9qv4c8nymiIwXkfo4PfjQuwqa4/T4i2onE8gEZx59pHGZ+BLaey/1QtQD38i3OTH3yYJpkQVVBqbeEJ/16I03QX0/I55HLyKNxS1qLSJd3DZ3AouBNiLSWkQq43TA3on0+xljjCmdcKZXTgN6AvVFJBu4H7eulKpOxJnldouI5AAHgP7q3G6bIyIjgNk40ysnu2P3phyauHIiw88Y7u3iTx51Hqs4Y/P/cMfoB0YjsBh76uOvAfjDhW18jsREw+QFzizyG7oHq8xziYleVQeUcPwZnOmXhR2bCcz0FppJJJ9995n3RL/RmYefm+g/a+SM0Qch0X+63imtbIk+Mfx3g/N+JlyiNyZuXOusVPV07vZ899aO3Jo3uaz2jYmRSYM7+x2CJ1brxhhjEpz16E1wuDVvptRyat4MKdhzL9izNybKglq7yBK9KRO1q9T2fnHVOs5j9ucArPylQeQBlZE6VSv7HYKJomXf/uR3CJ5Yojdl4vHzH/d+8TX/yN9WhLGUpYmDzvI7BBNFQX0/bYzeGGMSnPXoTZl4YukT3H7W7d4unpPhPFZxxuYn1XYeb2x/Y+SBxdgjs9YCcE96W58jMdEwfu56AH7f8ySfIykdS/SmTKzcvtL7xZsXO4/VnTr0647Wj0JEZWPZtz/6HYKJotVbfy75pDhkid4Ex9UvAjDW5zBM+fXMtWf6HYInNkZvjDEJznr0JjjcmjcT3TF6zyUVjPEoqLWLLNGbMtGoWiPvF9ds6jzucP6TZVWoF4WIykaTWsl+h2CiaOP2vX6H4IklelMmHj43gnXhf/N8/rYijKUsPdG/k98hmCgK6vtpY/TGGJPgrEdvysQjnz/CPV3uybcvb6Wp1s7SkUWuIPvBvc6jW6b4mTpOTZsRnUZEO8yoe+BdZwmG+y89zedITDQ89uE6AO7sfYrPkZSOJXoTNcUtEbh211rvDX/v/gqo08rZrHzAe1tlLKjzrk3htu4+6HcInliiN2UudP1YKMUaspePB+Bv0Q7ImDCNu/oMv0PwJJylBCcD/YBtqnp6IcevA3L/Jt8L3KKqK91jWcAe4AiQo6ppUYrbxLGCiXzorKE+RWKMgfB69FNwlgp8qYjj3wDnqeqPInIxkAl0DTl+vqruiChKYyCv5s0TdWoDeK+dY4xHQa1dFM6asfNEJLWY4/8N2VwENI9CXCaBtKrZKrIG6rmLPOzfBcBPVSMMqAyd0KCa3yGYKPpp/y9+h+BJtMfofwd8ELKtwIciosBzqpoZ5e9nAiDjVxmRNfDrp/K3F1lrZeqhKzv4HYKJoqC+n1FL9CJyPk6i7x6yu5uqbhWRhsBHIrJWVecVcf0wYBhAy5YtoxWWMcaUe1FJ9CLSAZgEXKyqO3P3q+pW93GbiLwFdAEKTfRubz8TIC0tTaMRl4kPGf/NcB699uzf+YPz6M6jH1fXWVpwVOdREUYWe/e9uQoIbk/Q5Pf391cD8P/6nupzJKUTcaIXkZbAm8AgVf1fyP5qQAVV3eM+7w2MifT7meD59udvwzqvsGmWXwz+AnY6CzLT0PkA7OCR4Mxl3rh9n98hmCg6ePio3yF4Es70ymlAT6C+iGQD9wOVAFR1IjAaqAeMFxE4No2yEfCWu68i8E9VnRWD12DKi77/B8CffQ7DlF9/vfy4GeaBEM6smwElHL8ROG5NN1XdCATz7gJTpr74ZpPzJGN33r6wb6IyxpTI7ow1ZS+jlrfr3Jo3j9RzxugL1s4xJtaCWrvIEr2JubZ1I7y5pHFwe/enNq3pdwjGWKI3sVdkzztkqKZYF+evQB+kfnzQen6meEF9P60evTHGJDjr0ZuYu3e+M7bueZWpN25yHpOdYZC/uWP0fz47/uff3P7qciC4KxOZ/P4y40sgeLNvLNGbmPth3w+RNfDzVuexekMAkpOCsw7rdwGtX24Kl1wpmIMgluhNcPT5OwDxfz+sSVRBuyM2VzB/PRljjAmb9ehNcLg1bzLq13UeI62KaUwpBbV2kSV6E3NnNIjwBukWnfNt1q5SO7L2ytCZrer4HYKJotpVK/sdgieW6E3MRbwSVK+M/O1F1lqZCtpKRKZ4QX0/LdGbxBNaYiHcm7KMSWCW6E3M3fGfOwB4/PzHvTUwfaDzWMWZR/9nd4z+b93/FnFssTb85aUATBx0ls+RmGgY9dpKAMZdHax6jZboTcz9dOinyBrY/6Pz2KAdAI2rFVEULbT37rVwWpT9GNA1Rk3hmtYKzj0coSzRm+C44P8BMMLnMEz5dWfvU/wOwRObR2+MMQkunBWmJgP9gG2qelyBB3GWkHoSuATYDwxR1WXusXT3WBIwSVU9Fjsx8caXhUHcmjf3NqwHRFA7xxiPglq7KJyhmynAM8BLRRy/GGjjfnUFJgBdRSQJeBa4CMgGFovIO6q6OtKgTbB0bdI1sgZOOC/fZmrN4NR473ZSfb9DMFF0QoPqfofgSThLCc4TkdRiTrkMeElVFVgkIrVFpAmQCqx3lxRERF51z7VEn0C+GPxFiecMP2N4ZN/kvLvztxdZa2XqDxe28TsEE0VBfT+jMUbfDNgcsp3t7itqvzHGmDIUjVk3Usg+LWZ/4Y2IDAOGAbRs2TIKYZl4MXyO0wef2Guitwb+8Rvn0Z1H/8eGznDI2PPGRhxbrA2e/DkAU2/o4nMkJhpG/HMZAM9ce6bPkZRONBJ9NtAiZLs5sBWoXMT+QqlqJpAJkJaWVuQvBBM8h3IORdbAYbeme6tuAJxSOzhj9AcPH/E7BBNFQV0DOBqJ/h1ghDsG3xXYrarfich2oI2ItAa2AP2Ba6Pw/Ux5de6dANzocxim/Pp9z5P8DsGTcKZXTgN6AvVFJBu4H6gEoKoTgZk4UyvX40yvHOoeyxGREcBsnOmVk1X1qxi8BmOMMcUIZ9bNgBKOK3BrEcdm4vwiMCZybs2bOxo2ACKonWOMR0GtXWQlEEzMndf8vJJPKs7JffJtnlErOOOkF7Zr6HcIJorObFXb7xA8sURvYm7I6UMia6DbH/K3F1lrZWpYjxP9DsFEUVDfT6t1Y4wxCc569Cbmhs4aCsCL6S96a+DFvs5jlRoAjGzkjNE/feHTEccWa9c8txCA6Tef43MkJhpunLoYgEmDO5dwZnyxRG+Cw61507VmDZ8DMeXVr04MZu0iS/QmOM6+BYCBPodhyq8burf2OwRPbIzeGGMSnPXoTXC4NW+GN3bG6D3XzjHGo6DWLrJEb2KuT2qfkk8qzmmX59vsGaAx+n4dmvgdgomiXgG9L8ISvYm5/m37R9ZAl5vytxdZa2Vq0Dmpfodgoiio76eN0ZuYO5BzgAM5B7w38Mt+5yuADvxyhAO/WAVL4y/r0ZuY+/2c3wMRzKN/5WrnsUISADc2cf58ntR7UsSxxdqQF50xXZtHnxium7QIgFduPNvnSErHEr2Ja+2ntmfyDz8A8H61agCknxP/C46YxNSvQ1O/Q/DEEr0JjDdqOgszZ5x8lc+RmPJqQJdgrn5nid7EpXyLjueWQGCTL7EYE3SW6E1gTP7OGcKJuHaOMR4FtXZRWIleRNKBJ3FWipqkqg8XOP5H4LqQNtsBDVR1l4hkAXuAI0COqqZFKXYTEJeddBnM+D0squWtgY7OCpRvf7r6WHsBcdVZzf0OwURRUN/PcJYSTAKeBS7CWQh8sYi8o6qrc89R1bHAWPf8S4E7VHVXSDPnq+qOqEZuAuPyky6HvYO9N9DJ6UO8vcrpX/ztpMsjD6qMXJ3Wwu8QTBQF9f0Mp0ffBVivqhsB3EXALwNWF3H+AGBadMIzieDHgz9ChQrUOXoUMnaXvoF9OwGoqArA4aOHAahUoVLUYoyVXft+AaButco+R2Ki4fCRowBUSgrWLUjhJPpmwOaQ7Wyga2EnikhVIB0YEbJbgQ9FRIHnVDXTY6wmoO6ceyc0rM+L32/z1sC/rgcg8wfn+mEfDgOCMUZ/yz+cNUaDNqZrCjdw0mdA8N7PcBK9FLJPizj3UuDTAsM23VR1q4g0BD4SkbWqOu+4byIyDBgG0LJlMKcwmdh6s4YzvfLKNlf6HIkpr/p3Sdyhm2wg9NU1B7YWcW5/CgzbqOpW93GbiLyFMxR0XKJ3e/qZAGlpaUX9IjHl2HvVnRumHjrxUp8jMeXVFZ0S9MNYYDHQRkRaA1twkvm1BU8SkVrAeYSsCyEi1YAKqrrHfd4bGBONwE3ZaT+1vd8hAJB81Bkfza2bk1Ixxc9wTDmUW7copXKSz5GUTomJXlVzRGQEMBtneuVkVf1KRIa7x3OLgl8BfKiq+0IubwS8JSK53+ufqjormi/AlB/jf9gORKF2jjEeBbV2UVjz6FV1JjCzwL6JBbanAFMK7NsInBFRhCZu5LtbtRSuOeUa+CKC3++dbwBg+idrjrUXEAPPbuV3CCaKgvp+2p2xJubSW6fDvgjKDJ/urCw1e2kGAONap0chqrJx6RnBLIJlChfU99MSvYm57/d9D0lJND7isS777mwAqrtj9Ht+2QNAjcrxv9LU1p+czxOa1rbPExLBzwedezhqJsf/PRyhLNGbmLtv/n3QoJ73efRv3gzAU+4Y/R/+/QcgGGP0d0xfAQRvTNcU7qapS4DgvZ+W6E1gvOKuFXtdu+tKONOY2BjaLdXvEDyxRG8C4+NqVQF4olUvnyMx5VX66cFc7N0SvQmM2u4Y/48HfwSgTnIdP8Mx5VBQaxdZojeB8dg2pwDqnXPvBIIxRm8SS1BrF1miNzE3+LTBsPID7w38yqmRN/XfI461FxA3nXuC3yGYKArq+2mJ3sRczxY94cAB7w2ccjEAnyxyxuifadEz8qDKSK9TG/kdgomioL6fluhNzH2z+xuoVJHWh3O8NbDjawDq5Thj9DsOOEM49VPqRyW+WNqwfS8AJzao7nMkJhq27TkIQMMayT5HUjqW6E3MjVk4BurV9T6P/t3bARi73Unwf/zkj0Awxuj/9KZTNiJoY7qmcCP/uRwI3vtpid7kEy+VKgvzQq2aAPyu/e98jsSUV7f0PNHvEDyxRG8C49OqThmBic26h39RRoEFyb0sZWiMq+cpDf0OwRNL9KZQXitVxlKjHGeM//t93wPQuFpjP8Mx5VBQaxdZojeB8dB2Z5Hw++bfB5QwRl+w516wZ2+MB0GtXWSJ3sTcsA7DYMX73hvoMQqAzI+GHWsvIEZe0MbvEEwUBfX9DCvRi0g68CTOClOTVPXhAsd7Am8D37i73lTVMeFcaxLfOU3PgYOHvDdw4vkALFrgTGl7vmlwelPd28T/FFATvqC+nyUmehFJAp4FLsJZKHyxiLyjqqsLnDpfVft5vNYksLW71kLlSrT95bC3Br5bBUBzdx7+5j2bAWhRo0WRl8SLr7Y6Q0inNbWho0SwaaezgE7LelV9jqR0wunRdwHWu8sCIiKvApcB4STrSK41CeKRzx+BunW8z6Of5YzJj9nhjNGP/nQ0EIx59GPedX7Ugzamawr3x9dXAsF7P8NJ9M2AzSHb2UDXQs47R0RWAluBUar6VSmuNaZE42s7veLfd/y9z5GY8uqOi072OwRPwkn0Usg+LbC9DGilqntF5BJgBtAmzGudbyIyDBgG0LJlyzDCMuXNkhRnjL5z484+R2LKq7NPqOd3CJ6Ek+izgdDB0OY4vfY8qvpzyPOZIjJeROqHc23IdZlAJkBaWlqhvwxM+ZbqjvEXdvduPM77N4knqLWLKoRxzmKgjYi0FpHKQH/gndATRKSxiIj7vIvb7s5wrjUmXKN37mL0zl1+h2HKsT+9+UVe/aIgKbFHr6o5IjICmI0zRXKyqn4lIsPd4xOBq4BbRCQHOAD0V1UFCr02Rq/FxKnbzrwNlr/nvYELnQ9fcwdsXk6uAkDHhh3jujYPwN3pp/gdgomioL6fYc2jV9WZwMwC+yaGPH8GeCbca0350rFhRzj0i/cGWub//L5jRNGUrbNa1fU7BBNFQX0/7c7YcqysesMrtq2AKpXp6DXZb/rMeaxSA4CvK1cCoE2d+L9Lcem3zlBTUBOEyW/d93sAOKVxDZ8jKR1L9Cbmnlz2JNSp7X0e/cdj8m0+2MSpIBiEefSPzloHBG/etSnc6Le/BIL3flqiN8GZsdLbSfh3VanicyCmvPrTJe38DsETS/QmOJqdBcDpPodhyq8zWtT2OwRPLNGb4HBr3qytUhmAtnXb+hmNKYeCWrvIEr0JDrfmzSORjNGH1qW31aZMKQW1dpElehNz93S5B5a9672B9Ifyt+f26INg9KWn+h2CiaKgvp+W6E1shPScIx5gadIh36an9kJ772W42lTQ/sQ3xQvq+2mJ3sTcQvdO1nO8Lj6y4T/OY3JNAL50Z92cXr/0H8um3vs+WcnHnnuR9XDfsM9d8PUOILgLVpj8Vm7+CQjeh7KW6E1sZewmc9ZQAM7xOu993rh8m/8XoHn0T//7a8ASfaJ4cOYawMbojYmdS8YC8Cf3zthIlaZnDt7/AjCJY8xlwZzca4neBEcj54Ow+C98kDii8cuttL9Q41nQSh/kskRvgsOteXPCi0sBOHqgFTXcGxXjvbftZ8KM93+bIAlq7SJL9CY43Jo3VRokAXBg082+hFEeE6eXXzKJ+O8U1NpFluhNzI0+Z3RkDVz6RL7Ng099CjjJp/3Ue/Oehy0jsnAi4WfCTKQhFL88eGV8r39QFEv0JuZa12odWQP184/K6y//i6w9jyxRmqAtIZgrrEQvIunAkzirRE1S1YcLHL8OuMfd3Avcoqor3WNZwB7gCJCjqmnRCd3ElWJuQpq7eS4APVv09Nb2ug+cR7cefVLVjd7a8cGc1T8A0OvURj5HYqJh0cadQPAWCS8x0YtIEvAscBHOYt+LReQdVV0dcto3wHmq+qOIXIyzyHfoskDnq+qOKMZtAmTqV1OBCBL9f/MvXla5fpL7bKT3oMrI8/OdX0rRSPSJOOYdNI9/5Pw1mYhj9F2A9aq6EUBEXgUuA/ISvar+N+T8RUDzaAZpAiSWhcIucxL+wcfnx+57GFOMsVed4XcInoST6JsBm0O2s8nfWy/od8AHIdsKfCgiCjynqpmljtIYgLrOWL8eXl3CiYnFPhuIHy3rVfU7BE/CSfRSyD4t9ESR83ESffeQ3d1UdauINAQ+EpG1qjqvkGuHAcMAWrZsGUZYptxxa94kVf3a50BMeRXU2kXhJPpsoEXIdnNga8GTRKQDMAm4WFV35u5X1a3u4zYReQtnKOi4RO/29DMB0tLSCv1FYso5t+bNsTH62/MOFbbQeWCWSDSBEdTaReEk+sVAGxFpDWwB+gPXhp4gIi2BN4FBqvq/kP3VgAqqusd93hvIv9KzSXgPnZu/nnxpP1RswjX5tg9WTCrizPjz+DUd/Q7BRFFQ388SE72q5ojICGA2zvTKyar6lYgMd49PBEYD9YDxIgLHplE2At5y91UE/qmqs2LySkyJCuv1loXG1RpHdP13FJjKlnPsaWG9dr9eZ2Ga1k7xOwQTRUF9P8OaR6+qM4GZBfZNDHl+I3BjIddtBIL5MbWJmlnfOL/b01un59sf9oeMX77hPFZx5uovqJoctdhi7d2VzijnpWc09TkSEw1z120DoOcpDX2OpHTszthyqKzHrqevmw4cn+jDtnhyvs0X3Hr03Zt1L+zsuPKPRd8ClugTxYS5GwBL9MbEzlVOwh8brTH6gnfz2mLhpgRPX9vJ7xA8sURvgqOGc3dpsOY7mETSsEZwhg1DWaI3nhScOVPcOqwpLXcWeaxU3Jo3c6s6H4h5LqlQsOdehouFl0eRvO/xdrNYUGsXWaI3weHWvJnqjtF7TvTGeBTN2kVlyRK98Swr+drj9xXSA/vx4K8AqJNcx9s3+u1L+TYfS6rgrR0fTBh4lt8h+CaS3ni8FnAL6vtpiT5BxdNccs8JPle1/PPoI2ytTNWtVtnvEEwUBfX9tERfjkWt11TCbJUZ62cAcPlJl3trf/krzqNbj35ONaewVK9Wvby1V4ZeW+LUA7w6rUUJZ5ogmPXldwCkn97E50hKxxJ9govmnPnChmrC8fb6t4EIEv2Kf+bbfMUdow9Con99aTZgiT5RvPhpFmCJ3gRQ2GOpGTENo2QDnIT/VIXwxuit0JmJtucHB3OBPEv0pvT8urEo2ZkGWcOf724MNZMr+R2CJ5boTXC4NW9mVasGFF1SId4LnZngCmrtIkv0AVfUB6o12hV/PJDcmjfT3TF6z7VzTGBE+vMb7Ruuglq7yBK9ibnxvcZH1sB1r+Vvr0Jhi55FQXF3yHocrpoytIvHYEw0RPuu3KC+n5boE0TBH8r2U+8tdL8fUipGWMO7cv51OiNprdAPaMO50GMBtJTKwVkkJZ5E+nMbq79kg/p+WqL3WTR+IGu0uzcvsUddFOrAvLr2VQD6t+3vrYHPn3ceq9QE4N3qTuK/9MRLI44NKD5pR/j6X16YBcCgc1IjaseUTqzuyn1ruTNd9opOzT237wdL9HGiRrvSJeo9ax6OUSTRNztrNhBBov9qRr7NN90x+tIkes8f0EZYAO29Vc4NNpboE8Ornzs3wCVkoheRdOBJnKUEJ6nqwwWOi3v8EmA/MERVl4VzrfGmsF8MMZ0jHg+12q+fAUBmlIfoCyZ8m2tvoPiefUl/icfDkGmoEhO9iCQBzwIXAdnAYhF5R1VXh5x2MdDG/eoKTAC6hnltXIiX2SklJZmYTxOM55K9Sc4c5mDOZDblSbyVZg6nR98FWO+u/4qIvApcBoQm68uAl1RVgUUiUltEmgCpYVwbNfGSrGOpXPc23Zo3M2o48+g9l1RwFfy3tLn2BopPtCXVLorXHBROom8GbA7ZzsbptZd0TrMwr40rfv3JFbMPU72Kh6GagtyaN2+7Y/SRJnpjSquk2kXxWpo5nERf2IiohnlOONc6DYgMA4a5m3tFZF0YsUWdPFKq0+sDO6L6/YfEaI540Qp/DQ9EP44pTIlle1F7L8J6D0r57/Ov4WGfGvWfKZ8k9OsoxftZaqXMQaFaFXUgnESfDYT++moObA3znMphXAuAqmYCmWHEEzdEZImqBrPKkSsRXgPY64g39jriSzhlABcDbUSktYhUBvoD7xQ45x3genGcDexW1e/CvNYYY0wMldijV9UcERkBzMaZIjlZVb8SkeHu8YnATJypletxplcOLe7amLwSY4wxhQprHr2qzsRJ5qH7JoY8V+DWcK9NIIEaaipCIrwGsNcRb+x1xBFxcrQxxphEFd5SPcYYYwLLEn0ERORqEflKRI6KSOA+mReRdBFZJyLrRSTOJvKHR0Qmi8g2EfnS71giISItROQ/IrLG/Zm6ze+YvBCRZBH5XERWuq/jAb9j8kpEkkRkuYi853cskbJEH5kvgSuBeX4HUloh5SkuBk4FBojIqf5G5ckUIBFWIMkB7lLVdsDZwK0BfT8OAReo6hlARyDdnYkXRLcBa/wOIhos0UdAVdeoqi83dkVBXmkLVf0FyC1PESiqOg/Y5XcckVLV73ILAarqHpwE08zfqEpPHXvdzUruV+A+CBSR5kBfYJLfsUSDJfryq6iyFcZnIpIKdAI+8zkUT9whjxXANuAjVQ3i63gCuBs46nMcUWGJvgQiMkdEvizkK3C93wLCLk9hyo6IVAfeAG5X1Z/9jscLVT2iqh1x7oTvIiKn+xxSqYhIP2Cbqi71O5ZosYVHSqCqvfyOIUbCKW1hypCIVMJJ8q+o6pt+xxMpVf1JRObifIYSpA/LuwG/FpFLgGSgpoj8Q1UH+hyXZ9ajL7+sPEUccRfveQFYo6qP+R2PVyLSQERqu89TgF7AWl+DKiVVvU9Vm6tqKs7/i38HOcmDJfqIiMgVIpINnAO8LyKz/Y4pXKqaA+SWp1gD/CuI5SlEZBqwEDhFRLJF5Hd+x+RRN2AQcIGIrHC/LvE7KA+aAP8RkVU4nYmPVDXw0xODzu6MNcaYBGc9emOMSXCW6I0xJsFZojfGmARnid4YYxKcJXpjjImCaBbYE5FWIrLUnX2Vt9CTe6y1iHwmIl+LyHR3enSxLNEbY0x0TCF6Bfa+A37l3mHcFbhXRJq6xx4BHlfVNsCPQIlTii3RG1MCEWkvIt8H7VZ+U7YKK7AnIieKyCy3dz5fRNqG2dYvqnrI3ayCm6vdG+suAF53j00FLi+pPUv0xpTsT8Cv3EdjSiMTGKmqZwGjgPHhXuiuUbAKp/jgI6q6FagH/OTe8AhhFiO0WjfGlEBVB7hPr/U1EBMoboG6XwGvOR1xwOmdIyJXAmMKuWyLqvYBUNXNQAd3yGaGiLxO4dU0S7zr1RK9MaUkIpfj1CpvCDyrqh/6G5GJUxVwet8dCx5wi9aFVbhOVbeKyFfAuThF72qLSEW3Vx9WMUIbujGmBCLyjIh8m7utqjNU9SZgCHCNb4GZuOaWmf5GRK4GZ3xdRM4I51oRae4WhUNE6uDUQlqnTs2a/wBXuacOBt4uqT1L9MYUQ0RaAz2ByiJSo8DhP+Msx2hMUQX2rgN+JyIrga8IfxW3dsBn7nWfAONU9Qv32D3AnSKyHmfM/oUSY7OiZsYUTUReAmYCNwH/T1UXuTMfHsapzDjH1wCNCYP16I0pgoicBpwOTMcp5Xyae2gkTp31q0JvZDEmXlmP3pgiiMgM4HlVfV9EbgVOUtU7fA7LmFKzRG9MIUSkKzAX+MHdlQysUtXevgVljEc2vdKYwj0I9FPVjwFEpBGw3N+QjPHGxuiNKUBELgKq5CZ5AFX9AagmInX9i8wYb2zoxhhjEpz16I0xJsFZojfGmARnid4YYxKcJXpjjElwluiNMSbBWaI3xpgEZ4neGGMSnCV6Y4xJcJbojTEmwf1/vQk8YfdskPYAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.hist(noisemarg_OS, histtype='step', lw=2, label='Hellings-Downs', color='C0', bins=20, density=True)\n",
+    "plt.hist(noisemarg_OS_mono, histtype='step', lw=2, label='Monopole', color='C1', bins=20, density=True)\n",
+    "plt.hist(noisemarg_OS_dip, histtype='step', lw=2, label='Dipole', color='C2', bins=20, density=True)\n",
+    "\n",
+    "plt.gca().axvline(x=np.mean(noisemarg_OS), ls='--', color='C0')\n",
+    "plt.gca().axvline(x=np.mean(noisemarg_OS_mono), ls='--', color='C1')\n",
+    "plt.gca().axvline(x=np.mean(noisemarg_OS_dip), ls='--', color='C2')\n",
+    "\n",
+    "plt.gca().axvline(x=OS, ls=':', color='C0')\n",
+    "plt.gca().axvline(x=OS_mono, ls=':', color='C1')\n",
+    "plt.gca().axvline(x=OS_dip, ls=':', color='C2')\n",
+    "\n",
+    "plt.legend(loc=\"upper right\")\n",
+    "plt.xlabel(r'$\\hat{A}^2$')"
    ]
   },
   {
@@ -325,7 +1096,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.12"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
 This now reproduces Figs 4 and 5 of 12.5yr GWB paper. Plus it uses an HDF5 file instead of chain file thus decreasing the file size from 1.9GB to 78MB (file not included).